### PR TITLE
Separation as array every 50k 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Example:
 package main
 
 import (
-	"os"
 	"time"
+	"bytes"
+	"fmt"
 
 	sitemap "github.com/PlanitarInc/go-sitemap"
 )
@@ -46,6 +47,7 @@ func (e SimpleEntry) GetImages() []string {
 }
 
 func main() {
+	var output []bytes.Buffer
 	entries := []SimpleEntry{
 		SimpleEntry{
 			Url:      "http://example.com/",
@@ -61,7 +63,8 @@ func main() {
 		},
 	}
 
-	sitemap.SitemapWrite(os.Stdout, &ArrayInput{Arr: entries})
+	sitemap.SitemapWrite(&output, &ArrayInput{Arr: entries})
+	fmt.Println(output[0].String())
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-A golang library for generation of sitemap XML files.
+[![Go Reference](https://pkg.go.dev/badge/github.com/PlanitarInc/go-sitemap.svg)](https://pkg.go.dev/github.com/PlanitarInc/go-sitemap)
+![CI Status](https://github.com/PlanitarInc/go-sitemap/actions/workflows/ci-flow.yml/badge.svg?branch=master)
+
+A GO library for generation of sitemap XML files.
 
 Example:
 
@@ -6,9 +9,8 @@ Example:
 package main
 
 import (
+	"os"
 	"time"
-	"bytes"
-	"fmt"
 
 	sitemap "github.com/PlanitarInc/go-sitemap"
 )
@@ -47,7 +49,6 @@ func (e SimpleEntry) GetImages() []string {
 }
 
 func main() {
-	var output []bytes.Buffer
 	entries := []SimpleEntry{
 		SimpleEntry{
 			Url:      "http://example.com/",
@@ -63,8 +64,7 @@ func main() {
 		},
 	}
 
-	sitemap.SitemapWrite(&output, &ArrayInput{Arr: entries})
-	fmt.Println(output[0].String())
+	sitemap.SitemapWrite(os.Stdout, &ArrayInput{Arr: entries})
 }
 ```
 

--- a/channel-input.go
+++ b/channel-input.go
@@ -1,6 +1,9 @@
 package sitemap
 
-import "sync/atomic"
+import (
+	"strconv"
+	"sync/atomic"
+)
 
 type ChannelInput struct {
 	channel       chan UrlEntry
@@ -48,4 +51,8 @@ func (in *ChannelInput) HasNext() bool {
 
 func (in *ChannelInput) Next() UrlEntry {
 	return in.lastReadEntry
+}
+
+func (in *ChannelInput) GetUrlsetUrl(idx int) string {
+	return "https://youriguide.com/sitemap/view" + strconv.Itoa(idx+1) + ".xml"
 }

--- a/channel-input_test.go
+++ b/channel-input_test.go
@@ -1,7 +1,6 @@
 package sitemap
 
 import (
-	"bytes"
 	"testing"
 	"time"
 
@@ -115,7 +114,7 @@ func TestChannelInputHasNext(t *testing.T) {
 func TestSitemapWriteChannelInput(t *testing.T) {
 	RegisterTestingT(t)
 
-	out := &bytes.Buffer{}
+	var out SiteMapOutlet
 	in := NewChannelInput()
 
 	go func(in *ChannelInput) {
@@ -134,8 +133,8 @@ func TestSitemapWriteChannelInput(t *testing.T) {
 		in.Close()
 	}(in)
 
-	Ω(SitemapWrite(out, in)).Should(BeNil())
-	Ω(out.String()).Should(MatchXML(`
+	Ω(WriteWithIndex(&out, in, 5)).Should(BeNil())
+	Ω(out.siteMapBuf[0].String()).Should(MatchXML(`
 		<?xml version="1.0" encoding="UTF-8"?>
 		<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
 			xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">

--- a/example/main.go
+++ b/example/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"os"
 	"time"
+	"bytes"
+	"fmt"
 
 	sitemap "github.com/PlanitarInc/go-sitemap"
 )
@@ -41,6 +42,7 @@ func (e SimpleEntry) GetImages() []string {
 }
 
 func main() {
+	var output []bytes.Buffer
 	entries := []SimpleEntry{
 		SimpleEntry{
 			Url:      "http://example.com/",
@@ -56,5 +58,6 @@ func main() {
 		},
 	}
 
-	sitemap.SitemapWrite(os.Stdout, &ArrayInput{Arr: entries})
+	sitemap.SitemapWrite(&output, &ArrayInput{Arr: entries})
+	fmt.Println(output[0].String())
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,101 @@
+package sitemap_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/PlanitarInc/go-sitemap"
+)
+
+type SiteMapOutlet struct {
+	indexBuf   bytes.Buffer
+	siteMapBuf []bytes.Buffer
+}
+
+func (out *SiteMapOutlet) Index() io.Writer {
+	return &out.indexBuf
+}
+
+func (out *SiteMapOutlet) Urlset() io.Writer {
+	out.siteMapBuf = append(out.siteMapBuf, bytes.Buffer{})
+	return &out.siteMapBuf[len(out.siteMapBuf)-1]
+}
+
+func ExampleWriteWithIndex() {
+	var out SiteMapOutlet
+	entries := []SimpleEntry{
+		{
+			Url:      "http://example.com/",
+			Modified: time.Date(2025, time.November, 2, 11, 34, 58, 123, time.UTC),
+		},
+		{
+			Url: "http://example.com/test/",
+			ImageUrls: []string{
+				"http://example.com/test/1.jpg",
+				"http://example.com/test/2.jpg",
+				"http://example.com/test/3.jpg",
+			},
+		},
+	}
+
+	_ = sitemap.WriteWithIndex(&out, &ArrayInput{Arr: entries}, 5)
+	fmt.Println(out.siteMapBuf[0].String())
+	// Output: <?xml version="1.0" encoding="UTF-8"?>
+	// <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+	//   <url>
+	//     <loc>http://example.com/</loc>
+	//     <lastmod>2025-11-02T11:34:58Z</lastmod>
+	//   </url>
+	//   <url>
+	//     <loc>http://example.com/test/</loc>
+	//     <image:image>
+	//       <image:loc>http://example.com/test/1.jpg</image:loc>
+	//     </image:image>
+	//     <image:image>
+	//       <image:loc>http://example.com/test/2.jpg</image:loc>
+	//     </image:image>
+	//     <image:image>
+	//       <image:loc>http://example.com/test/3.jpg</image:loc>
+	//     </image:image>
+	//   </url>
+	// </urlset>
+}
+
+type ArrayInput struct {
+	Arr     []SimpleEntry
+	NextIdx int
+}
+
+func (a ArrayInput) HasNext() bool {
+	return a.NextIdx < len(a.Arr)
+}
+
+func (a *ArrayInput) Next() sitemap.UrlEntry {
+	idx := a.NextIdx
+	a.NextIdx++
+	return a.Arr[idx]
+}
+
+type SimpleEntry struct {
+	Url       string
+	Modified  time.Time
+	ImageUrls []string
+}
+
+func (e SimpleEntry) GetLoc() string {
+	return e.Url
+}
+
+func (e SimpleEntry) GetLastMod() time.Time {
+	return e.Modified
+}
+
+func (e SimpleEntry) GetImages() []string {
+	return e.ImageUrls
+}
+
+func (a *ArrayInput) GetUrlsetUrl(idx int) string {
+	return ""
+}

--- a/input.go
+++ b/input.go
@@ -5,6 +5,7 @@ import "time"
 type Input interface {
 	Next() UrlEntry
 	HasNext() bool
+	GetUrlsetUrl(idx int) string
 }
 
 type UrlEntry interface {

--- a/sitemap.go
+++ b/sitemap.go
@@ -1,8 +1,8 @@
 package sitemap
 
 import (
-	"bytes"
 	"encoding/xml"
+	"errors"
 	"io"
 	"time"
 )
@@ -29,72 +29,133 @@ func t2str(t time.Time) string {
 	return t.Format(time.RFC3339)
 }
 
+type Output interface {
+	Index() io.Writer
+	Urlset() io.Writer
+}
+
+func WriteWithIndex(o Output, in Input, max int) error {
+	var nfiles int
+	for {
+		nfiles++
+		err := writeUrlset(o.Urlset(), in, max)
+		if err != nil && !errors.Is(err, errMaxCapReached{}) {
+			return err
+		}
+
+		if err == nil {
+			return writeIndex(o.Index(), in, nfiles)
+		}
+	}
+}
+
+func writeIndex(w io.Writer, in Input, nfiles int) error {
+	// XXX write the header and initialize the XML encoder
+	sitemapindex := xml.Name{Local: "sitemapindex"}
+	start := xml.StartElement{
+		Name: sitemapindex,
+		Attr: []xml.Attr{
+			xml.Attr{
+				Name:  xml.Name{Local: "xmlns"},
+				Value: "http://www.sitemaps.org/schemas/sitemap/0.9",
+			},
+		},
+	}
+	if _, err := io.WriteString(w, xml.Header); err != nil {
+		return err
+	}
+	e := xml.NewEncoder(w)
+	e.Indent("", "  ")
+
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+
+	sitemap := Url{}
+	for i := 0; i < nfiles; i++ {
+		sitemap.Loc = in.GetUrlsetUrl(i)
+
+		if err := e.Encode(sitemap); err != nil {
+			return err
+		}
+	}
+	if err := e.EncodeToken(start.End()); err != nil {
+		return err
+	}
+
+	return e.Flush()
+}
+
 // XXX The limitation of file size:
 //  - according to http://www.sitemaps.org/protocol.html:
 //     <50.000 urls and <10MB
 // XXX It should be fine until we reach 10.000 entries
-func SitemapWrite(w *[]bytes.Buffer, in Input) error {
-	const maxEntry int = 50000
-	i := 0
-	hasNext := in.HasNext()
-	for hasNext {
-		urlset := xml.Name{Local: "urlset"}
-		start := xml.StartElement{
-			Name: urlset,
-			Attr: []xml.Attr{
-				xml.Attr{
-					Name:  xml.Name{Local: "xmlns"},
-					Value: "http://www.sitemaps.org/schemas/sitemap/0.9",
-				},
-				xml.Attr{
-					Name:  xml.Name{Local: "xmlns:image"},
-					Value: "http://www.google.com/schemas/sitemap-image/1.1",
-				},
+func writeUrlset(w io.Writer, in Input, max int) error {
+	urlset := xml.Name{Local: "urlset"}
+	start := xml.StartElement{
+		Name: urlset,
+		Attr: []xml.Attr{
+			{
+				Name:  xml.Name{Local: "xmlns"},
+				Value: "http://www.sitemaps.org/schemas/sitemap/0.9",
 			},
-		}
-		*w = append(*w, bytes.Buffer{})
-		io.WriteString(&(*w)[i], xml.Header)
-		e := xml.NewEncoder(&(*w)[i])
-		e.Indent("", "  ")
+			{
+				Name:  xml.Name{Local: "xmlns:image"},
+				Value: "http://www.google.com/schemas/sitemap-image/1.1",
+			},
+		},
+	}
 
-		if err := e.EncodeToken(start); err != nil {
+	_, _ = io.WriteString(w, xml.Header)
+	e := xml.NewEncoder(w)
+	e.Indent("", "  ")
+
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+
+	url := Url{}
+	image := Image{}
+	var count int
+	for in.HasNext() {
+		entry := in.Next()
+
+		url.Loc = entry.GetLoc()
+		url.LastMod = t2str(entry.GetLastMod())
+		url.Images = []Image{}
+		for _, imageUrl := range entry.GetImages() {
+			image.Loc = imageUrl
+			url.Images = append(url.Images, image)
+		}
+
+		if err := e.Encode(url); err != nil {
 			return err
 		}
 
-		url := Url{}
-		image := Image{}
-		counter := 1
-		for hasNext {
-			entry := in.Next()
-
-			url.Loc = entry.GetLoc()
-			url.LastMod = t2str(entry.GetLastMod())
-			url.Images = []Image{}
-			for _, imageUrl := range entry.GetImages() {
-				image.Loc = imageUrl
-				url.Images = append(url.Images, image)
-			}
-
-			hasNext = in.HasNext()	
-			if err := e.Encode(url); err != nil {
+		count++
+		if count >= max { // if count >= 50_000 {
+			// XXX finalize the file and return the error
+			if err := e.EncodeToken(start.End()); err != nil {
 				return err
 			}
 
-			counter++
-			if counter > maxEntry {
-				i++
-				break
+			if err := e.Flush(); err != nil {
+				return err
 			}
-		}
 
-		if err := e.EncodeToken(start.End()); err != nil {
-			return err
-		}
-
-		if err := e.Flush(); err != nil {
-			return err
+			return errMaxCapReached{}
 		}
 	}
 
-	return nil
+	if err := e.EncodeToken(start.End()); err != nil {
+		return err
+	}
+
+	return e.Flush()
+}
+
+type errMaxCapReached struct{}
+
+func (e errMaxCapReached) Error() string {
+	return "Max 50K capacity is reached"
 }


### PR DESCRIPTION
This PR changes the return value to be an array. Each array contains 50000 elements. This resolves the sitemap protocol for 50000 restrictions.

Related to https://github.com/PlanitarInc/walk-inside-api/pull/992
Related to https://github.com/PlanitarInc/youriguide.com/issues/2410
Related to https://planitar.atlassian.net/browse/PRTL-359