### PR TITLE
Reduce memory consumption

### DIFF
--- a/channel-input.go
+++ b/channel-input.go
@@ -3,20 +3,20 @@ package sitemap
 import "sync/atomic"
 
 type ChannelInput struct {
-	channel       chan UrlEntry
+	channel       chan *UrlEntry
 	closed        int32
-	lastReadEntry UrlEntry
+	lastReadEntry *UrlEntry
 	getUrlsetUrl  func(int) string
 }
 
 func NewChannelInput(getUrlsetUrl func(int) string) *ChannelInput {
 	return &ChannelInput{
-		channel:      make(chan UrlEntry),
+		channel:      make(chan *UrlEntry),
 		getUrlsetUrl: getUrlsetUrl,
 	}
 }
 
-func (in *ChannelInput) Feed(entry UrlEntry) {
+func (in *ChannelInput) Feed(entry *UrlEntry) {
 	if atomic.LoadInt32(&in.closed) > 0 {
 		return
 	}
@@ -48,7 +48,7 @@ func (in *ChannelInput) HasNext() bool {
 	return true
 }
 
-func (in *ChannelInput) Next() UrlEntry {
+func (in *ChannelInput) Next() *UrlEntry {
 	return in.lastReadEntry
 }
 

--- a/channel-input_test.go
+++ b/channel-input_test.go
@@ -51,8 +51,8 @@ func TestChannelInput_Feed(t *testing.T) {
 		RegisterTestingT(t)
 
 		in := NewChannelInput(nil)
-		go in.Feed(&simpleEntry{Loc: "one"})
-		Eventually(in.channel).Should(Receive(Equal(&simpleEntry{Loc: "one"})))
+		go in.Feed(&UrlEntry{Loc: "one"})
+		Eventually(in.channel).Should(Receive(Equal(&UrlEntry{Loc: "one"})))
 		Ω(in.channel).ShouldNot(BeClosed())
 	})
 
@@ -62,7 +62,7 @@ func TestChannelInput_Feed(t *testing.T) {
 		in := NewChannelInput(nil)
 		in.Close()
 		Ω(in.channel).Should(BeClosed())
-		in.Feed(&simpleEntry{Loc: "one"})
+		in.Feed(&UrlEntry{Loc: "one"})
 	})
 }
 
@@ -78,9 +78,9 @@ func TestChannelInput_Next(t *testing.T) {
 		RegisterTestingT(t)
 
 		in := NewChannelInput(nil)
-		in.lastReadEntry = &simpleEntry{Loc: "one"}
+		in.lastReadEntry = &UrlEntry{Loc: "one"}
 
-		Ω(in.Next()).Should(Equal(&simpleEntry{Loc: "one"}))
+		Ω(in.Next()).Should(Equal(&UrlEntry{Loc: "one"}))
 	})
 }
 
@@ -91,16 +91,16 @@ func TestChannelInput_HasNext(t *testing.T) {
 		in := NewChannelInput(nil)
 
 		Ω(in.lastReadEntry).Should(BeNil())
-		go in.Feed(&simpleEntry{Loc: "one"})
+		go in.Feed(&UrlEntry{Loc: "one"})
 		Ω(in.HasNext()).Should(BeTrue())
-		Ω(in.lastReadEntry).Should(Equal(&simpleEntry{Loc: "one"}))
+		Ω(in.lastReadEntry).Should(Equal(&UrlEntry{Loc: "one"}))
 	})
 
 	t.Run("Close", func(t *testing.T) {
 		RegisterTestingT(t)
 
 		in := NewChannelInput(nil)
-		in.lastReadEntry = &simpleEntry{Loc: "one"}
+		in.lastReadEntry = &UrlEntry{Loc: "one"}
 
 		go func(in *ChannelInput) {
 			time.Sleep(100 * time.Millisecond)
@@ -140,15 +140,15 @@ func TestWriteAll_ChannelInput(t *testing.T) {
 	})
 
 	go func(in *ChannelInput) {
-		in.Feed(&simpleEntry{Loc: "a"})
+		in.Feed(&UrlEntry{Loc: "a"})
 	}(in)
 	go func(in *ChannelInput) {
 		time.Sleep(100 * time.Millisecond)
-		in.Feed(&simpleEntry{Loc: "b"})
+		in.Feed(&UrlEntry{Loc: "b"})
 	}(in)
 	go func(in *ChannelInput) {
 		time.Sleep(200 * time.Millisecond)
-		in.Feed(&simpleEntry{Loc: "c"})
+		in.Feed(&UrlEntry{Loc: "c"})
 	}(in)
 	go func(in *ChannelInput) {
 		time.Sleep(500 * time.Millisecond)

--- a/example_test.go
+++ b/example_test.go
@@ -11,14 +11,14 @@ import (
 )
 
 func ExampleWriteAll_stdout() {
-	entries := []SimpleEntry{
+	entries := []sitemap.UrlEntry{
 		{
-			Url:      "http://example.com/",
-			Modified: time.Date(2025, time.November, 2, 11, 34, 58, 123, time.UTC),
+			Loc:     "http://example.com/",
+			LastMod: time.Date(2025, time.November, 2, 11, 34, 58, 123, time.UTC),
 		},
 		{
-			Url: "http://example.com/test/",
-			ImageUrls: []string{
+			Loc: "http://example.com/test/",
+			Images: []string{
 				"http://example.com/test/1.jpg",
 				"http://example.com/test/2.jpg",
 				"http://example.com/test/3.jpg",
@@ -64,14 +64,14 @@ func ExampleWriteAll_stdout() {
 }
 
 func ExampleWriteAll_buffers() {
-	entries := []SimpleEntry{
+	entries := []sitemap.UrlEntry{
 		{
-			Url:      "http://example.com/",
-			Modified: time.Date(2025, time.November, 2, 11, 34, 58, 123, time.UTC),
+			Loc:     "http://example.com/",
+			LastMod: time.Date(2025, time.November, 2, 11, 34, 58, 123, time.UTC),
 		},
 		{
-			Url: "http://example.com/test/",
-			ImageUrls: []string{
+			Loc: "http://example.com/test/",
+			Images: []string{
 				"http://example.com/test/1.jpg",
 				"http://example.com/test/2.jpg",
 				"http://example.com/test/3.jpg",
@@ -155,7 +155,7 @@ func (o *bufferOutput) Urlset() io.Writer {
 }
 
 type arrayInput struct {
-	Arr     []SimpleEntry
+	Arr     []sitemap.UrlEntry
 	NextIdx int
 }
 
@@ -163,30 +163,12 @@ func (a arrayInput) HasNext() bool {
 	return a.NextIdx < len(a.Arr)
 }
 
-func (a *arrayInput) Next() sitemap.UrlEntry {
+func (a *arrayInput) Next() *sitemap.UrlEntry {
 	idx := a.NextIdx
 	a.NextIdx++
-	return a.Arr[idx]
+	return &a.Arr[idx]
 }
 
 func (a *arrayInput) GetUrlsetUrl(n int) string {
 	return fmt.Sprintf("https://example.com/sitemap-%d.xml", n)
-}
-
-type SimpleEntry struct {
-	Url       string
-	Modified  time.Time
-	ImageUrls []string
-}
-
-func (e SimpleEntry) GetLoc() string {
-	return e.Url
-}
-
-func (e SimpleEntry) GetLastMod() time.Time {
-	return e.Modified
-}
-
-func (e SimpleEntry) GetImages() []string {
-	return e.ImageUrls
 }

--- a/example_test.go
+++ b/example_test.go
@@ -13,15 +13,15 @@ import (
 func ExampleWriteAll_stdout() {
 	entries := []sitemap.UrlEntry{
 		{
-			Loc:     "http://example.com/",
+			Loc:     "http://goiguide.com/",
 			LastMod: time.Date(2025, time.November, 2, 11, 34, 58, 123, time.UTC),
 		},
 		{
-			Loc: "http://example.com/test/",
+			Loc: "http://goiguide.com/test/",
 			Images: []string{
-				"http://example.com/test/1.jpg",
-				"http://example.com/test/2.jpg",
-				"http://example.com/test/3.jpg",
+				"http://goiguide.com/test/1.jpg",
+				"http://goiguide.com/test/2.jpg",
+				"http://goiguide.com/test/3.jpg",
 			},
 		},
 	}
@@ -36,19 +36,19 @@ func ExampleWriteAll_stdout() {
 	// <?xml version="1.0" encoding="UTF-8"?>
 	// <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
 	//   <url>
-	//     <loc>http://example.com/</loc>
+	//     <loc>http://goiguide.com/</loc>
 	//     <lastmod>2025-11-02T11:34:58Z</lastmod>
 	//   </url>
 	//   <url>
-	//     <loc>http://example.com/test/</loc>
+	//     <loc>http://goiguide.com/test/</loc>
 	//     <image:image>
-	//       <image:loc>http://example.com/test/1.jpg</image:loc>
+	//       <image:loc>http://goiguide.com/test/1.jpg</image:loc>
 	//     </image:image>
 	//     <image:image>
-	//       <image:loc>http://example.com/test/2.jpg</image:loc>
+	//       <image:loc>http://goiguide.com/test/2.jpg</image:loc>
 	//     </image:image>
 	//     <image:image>
-	//       <image:loc>http://example.com/test/3.jpg</image:loc>
+	//       <image:loc>http://goiguide.com/test/3.jpg</image:loc>
 	//     </image:image>
 	//   </url>
 	// </urlset>
@@ -58,7 +58,7 @@ func ExampleWriteAll_stdout() {
 	// <?xml version="1.0" encoding="UTF-8"?>
 	// <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	//   <url>
-	//     <loc>https://example.com/sitemap-0.xml</loc>
+	//     <loc>https://goiguide.com/sitemap-0.xml</loc>
 	//   </url>
 	// </sitemapindex>
 }
@@ -66,15 +66,15 @@ func ExampleWriteAll_stdout() {
 func ExampleWriteAll_buffers() {
 	entries := []sitemap.UrlEntry{
 		{
-			Loc:     "http://example.com/",
+			Loc:     "http://goiguide.com/",
 			LastMod: time.Date(2025, time.November, 2, 11, 34, 58, 123, time.UTC),
 		},
 		{
-			Loc: "http://example.com/test/",
+			Loc: "http://goiguide.com/test/",
 			Images: []string{
-				"http://example.com/test/1.jpg",
-				"http://example.com/test/2.jpg",
-				"http://example.com/test/3.jpg",
+				"http://goiguide.com/test/1.jpg",
+				"http://goiguide.com/test/2.jpg",
+				"http://goiguide.com/test/3.jpg",
 			},
 		},
 	}
@@ -98,19 +98,19 @@ func ExampleWriteAll_buffers() {
 	// <?xml version="1.0" encoding="UTF-8"?>
 	// <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
 	//   <url>
-	//     <loc>http://example.com/</loc>
+	//     <loc>http://goiguide.com/</loc>
 	//     <lastmod>2025-11-02T11:34:58Z</lastmod>
 	//   </url>
 	//   <url>
-	//     <loc>http://example.com/test/</loc>
+	//     <loc>http://goiguide.com/test/</loc>
 	//     <image:image>
-	//       <image:loc>http://example.com/test/1.jpg</image:loc>
+	//       <image:loc>http://goiguide.com/test/1.jpg</image:loc>
 	//     </image:image>
 	//     <image:image>
-	//       <image:loc>http://example.com/test/2.jpg</image:loc>
+	//       <image:loc>http://goiguide.com/test/2.jpg</image:loc>
 	//     </image:image>
 	//     <image:image>
-	//       <image:loc>http://example.com/test/3.jpg</image:loc>
+	//       <image:loc>http://goiguide.com/test/3.jpg</image:loc>
 	//     </image:image>
 	//   </url>
 	// </urlset>
@@ -120,7 +120,50 @@ func ExampleWriteAll_buffers() {
 	// <?xml version="1.0" encoding="UTF-8"?>
 	// <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 	//   <url>
-	//     <loc>https://example.com/sitemap-0.xml</loc>
+	//     <loc>https://goiguide.com/sitemap-0.xml</loc>
+	//   </url>
+	// </sitemapindex>
+}
+
+func ExampleWriteAll_dynamicInput() {
+	err := sitemap.WriteAll(&stdoutOutput{}, &dynamicInput{Length: 3})
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
+	}
+	// Output:
+	// ::: Urlset 0
+
+	// <?xml version="1.0" encoding="UTF-8"?>
+	// <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+	//   <url>
+	//     <loc>https://goiguide.com/entry-00000</loc>
+	//     <lastmod>2020-10-31T11:00:00Z</lastmod>
+	//     <image:image>
+	//       <image:loc>https://goiguide.com/entry-00000/thumb.png</image:loc>
+	//     </image:image>
+	//   </url>
+	//   <url>
+	//     <loc>https://goiguide.com/entry-00001</loc>
+	//     <lastmod>2020-11-01T11:00:00Z</lastmod>
+	//     <image:image>
+	//       <image:loc>https://goiguide.com/entry-00001/thumb.png</image:loc>
+	//     </image:image>
+	//   </url>
+	//   <url>
+	//     <loc>https://goiguide.com/entry-00002</loc>
+	//     <lastmod>2020-11-02T11:00:00Z</lastmod>
+	//     <image:image>
+	//       <image:loc>https://goiguide.com/entry-00002/thumb.png</image:loc>
+	//     </image:image>
+	//   </url>
+	// </urlset>
+
+	// ::: Index
+
+	// <?xml version="1.0" encoding="UTF-8"?>
+	// <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+	//   <url>
+	//     <loc>https://goiguide.com/sitemap-00.xml</loc>
 	//   </url>
 	// </sitemapindex>
 }
@@ -156,19 +199,42 @@ func (o *bufferOutput) Urlset() io.Writer {
 
 type arrayInput struct {
 	Arr     []sitemap.UrlEntry
-	NextIdx int
+	nextIdx int
 }
 
 func (a arrayInput) HasNext() bool {
-	return a.NextIdx < len(a.Arr)
+	return a.nextIdx < len(a.Arr)
 }
 
 func (a *arrayInput) Next() *sitemap.UrlEntry {
-	idx := a.NextIdx
-	a.NextIdx++
+	idx := a.nextIdx
+	a.nextIdx++
 	return &a.Arr[idx]
 }
 
 func (a *arrayInput) GetUrlsetUrl(n int) string {
-	return fmt.Sprintf("https://example.com/sitemap-%d.xml", n)
+	return fmt.Sprintf("https://goiguide.com/sitemap-%d.xml", n)
+}
+
+type dynamicInput struct {
+	Length  int
+	nextIdx int
+	entry   sitemap.UrlEntry
+}
+
+func (d dynamicInput) HasNext() bool {
+	return d.nextIdx < d.Length
+}
+
+func (d *dynamicInput) Next() *sitemap.UrlEntry {
+	idx := d.nextIdx
+	d.nextIdx++
+	d.entry.Loc = fmt.Sprintf("https://goiguide.com/entry-%05d", idx)
+	d.entry.LastMod = time.Date(2020, time.November, idx, 11, 0, 0, 0, time.UTC)
+	d.entry.Images = []string{fmt.Sprintf("https://goiguide.com/entry-%05d/thumb.png", idx)}
+	return &d.entry
+}
+
+func (d dynamicInput) GetUrlsetUrl(n int) string {
+	return fmt.Sprintf("https://goiguide.com/sitemap-%02d.xml", n)
 }

--- a/interfaces.go
+++ b/interfaces.go
@@ -6,15 +6,15 @@ import (
 )
 
 type Input interface {
-	Next() UrlEntry
+	Next() *UrlEntry
 	HasNext() bool
 	GetUrlsetUrl(idx int) string
 }
 
-type UrlEntry interface {
-	GetLoc() string
-	GetLastMod() time.Time
-	GetImages() []string
+type UrlEntry struct {
+	Loc     string
+	LastMod time.Time
+	Images  []string
 }
 
 type Output interface {

--- a/sitemap.go
+++ b/sitemap.go
@@ -38,11 +38,11 @@ type sitemapWriter struct {
 func (s *sitemapWriter) writeIndexFile(w io.Writer, in Input, nfiles int) error {
 	abortWriter := abortWriter{underlying: w}
 
-	abortWriter.Write(indexHeader)
+	_, _ = abortWriter.Write(indexHeader)
 	for i := 0; i < nfiles; i++ {
 		s.writeXmlUrlLoc(&abortWriter, in.GetUrlsetUrl(i))
 	}
-	abortWriter.Write(indexFooter)
+	_, _ = abortWriter.Write(indexFooter)
 
 	return abortWriter.firstErr
 }
@@ -53,7 +53,7 @@ func (s *sitemapWriter) writeUrlsetFile(w io.Writer, in Input) error {
 	abortWriter := abortWriter{underlying: w}
 	var capErr error
 
-	abortWriter.Write(urlsetHeader)
+	_, _ = abortWriter.Write(urlsetHeader)
 	for count := 0; in.HasNext(); count++ {
 		if count >= maxSitemapCap {
 			capErr = errMaxCapReached{}
@@ -62,7 +62,7 @@ func (s *sitemapWriter) writeUrlsetFile(w io.Writer, in Input) error {
 
 		s.writeXmlUrlEntry(&abortWriter, in.Next())
 	}
-	abortWriter.Write(urlsetFooter)
+	_, _ = abortWriter.Write(urlsetFooter)
 
 	if abortWriter.firstErr != nil {
 		return abortWriter.firstErr
@@ -72,31 +72,31 @@ func (s *sitemapWriter) writeUrlsetFile(w io.Writer, in Input) error {
 }
 
 func (s *sitemapWriter) writeXmlUrlEntry(w io.Writer, e *UrlEntry) {
-	w.Write(tagUrlOpen)
-	w.Write(tagLocOpen)
+	_, _ = w.Write(tagUrlOpen)
+	_, _ = w.Write(tagLocOpen)
 	s.writeXmlString(w, e.Loc)
-	w.Write(tagLocClose)
+	_, _ = w.Write(tagLocClose)
 	if !e.LastMod.Before(minDate) {
-		w.Write(tagLastmodOpen)
+		_, _ = w.Write(tagLastmodOpen)
 		s.writeXmlTime(w, e.LastMod)
-		w.Write(tagLastmodClose)
+		_, _ = w.Write(tagLastmodClose)
 	}
 	if len(e.Images) > 0 {
 		for i := range e.Images {
-			w.Write(tagImageOpen)
+			_, _ = w.Write(tagImageOpen)
 			s.writeXmlString(w, e.Images[i])
-			w.Write(tagImageClose)
+			_, _ = w.Write(tagImageClose)
 		}
 	}
-	w.Write(tagUrlClose)
+	_, _ = w.Write(tagUrlClose)
 }
 
 func (s *sitemapWriter) writeXmlUrlLoc(w io.Writer, loc string) {
-	w.Write(tagUrlOpen)
-	w.Write(tagLocOpen)
+	_, _ = w.Write(tagUrlOpen)
+	_, _ = w.Write(tagLocOpen)
 	s.writeXmlString(w, loc)
-	w.Write(tagLocClose)
-	w.Write(tagUrlClose)
+	_, _ = w.Write(tagLocClose)
+	_, _ = w.Write(tagUrlClose)
 }
 
 func (s *sitemapWriter) writeXmlString(w io.Writer, str string) {
@@ -113,7 +113,7 @@ func (s *sitemapWriter) writeXmlTime(w io.Writer, t time.Time) {
 	s.buf.Reset()
 	s.buf.Grow(len(time.RFC3339) * 2) // *2 is just in case
 	bs := t.AppendFormat(s.buf.Bytes(), time.RFC3339)
-	w.Write(bs)
+	_, _ = w.Write(bs)
 }
 
 // Below are constant strings converted to byte slices ahead of time

--- a/sitemap.go
+++ b/sitemap.go
@@ -71,29 +71,20 @@ func (s *sitemapWriter) writeUrlsetFile(w io.Writer, in Input) error {
 	return capErr
 }
 
-func (s *sitemapWriter) writeXmlUrlEntry(w io.Writer, e UrlEntry) {
-	loc := e.GetLoc()
-	lastMod := e.GetLastMod()
-	images := e.GetImages()
-	if lastMod.Before(minDate) && len(images) == 0 {
-		// fast path
-		s.writeXmlUrlLoc(w, loc)
-		return
-	}
-
+func (s *sitemapWriter) writeXmlUrlEntry(w io.Writer, e *UrlEntry) {
 	w.Write(tagUrlOpen)
 	w.Write(tagLocOpen)
-	s.writeXmlString(w, loc)
+	s.writeXmlString(w, e.Loc)
 	w.Write(tagLocClose)
-	if !lastMod.Before(minDate) {
+	if !e.LastMod.Before(minDate) {
 		w.Write(tagLastmodOpen)
-		s.writeXmlTime(w, lastMod)
+		s.writeXmlTime(w, e.LastMod)
 		w.Write(tagLastmodClose)
 	}
-	if len(images) > 0 {
-		for i := range images {
+	if len(e.Images) > 0 {
+		for i := range e.Images {
 			w.Write(tagImageOpen)
-			s.writeXmlString(w, images[i])
+			s.writeXmlString(w, e.Images[i])
 			w.Write(tagImageClose)
 		}
 	}

--- a/sitemap.go
+++ b/sitemap.go
@@ -7,19 +7,6 @@ import (
 	"time"
 )
 
-type Url struct {
-	XMLName xml.Name `xml:"url"`
-	Loc     string   `xml:"loc"`
-	LastMod string   `xml:"lastmod,omitempty"`
-	Images  []Image  `xml:"image:image,omitempty"`
-	//      Priority   float32   `xml:"priority"`
-	//      ChangeFreq string    `xml:"changefreq,omitempty"`
-}
-
-type Image struct {
-	Loc string `xml:"image:loc"`
-}
-
 var minDate = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 
 func t2str(t time.Time) string {
@@ -36,119 +23,141 @@ func t2str(t time.Time) string {
 // by o.Index().
 // The function aborts if any unexpected error occurs when writing.
 func WriteAll(o Output, in Input) error {
+	var s sitemapWriter
 	var nfiles int
 	for {
 		nfiles++
-		err := writeUrlsetFile(o.Urlset(), in)
+		err := s.writeUrlsetFile(o.Urlset(), in)
 		if err != nil && !errors.Is(err, errMaxCapReached{}) {
 			return err
 		}
 
 		if err == nil {
-			return writeIndexFile(o.Index(), in, nfiles)
+			return s.writeIndexFile(o.Index(), in, nfiles)
 		}
 	}
 }
 
+type sitemapWriter struct{}
+
 // writeIndexFile writes Sitemap index file for N files.
-func writeIndexFile(w io.Writer, in Input, nfiles int) error {
-	start := xml.StartElement{
-		Name: xml.Name{Local: "sitemapindex"},
-		Attr: []xml.Attr{
-			{
-				Name:  xml.Name{Local: "xmlns"},
-				Value: "http://www.sitemaps.org/schemas/sitemap/0.9",
-			},
-		},
-	}
+func (s *sitemapWriter) writeIndexFile(w io.Writer, in Input, nfiles int) error {
+	abortWriter := abortWriter{underlying: w}
 
-	if _, err := io.WriteString(w, xml.Header); err != nil {
-		return err
-	}
-
-	e := xml.NewEncoder(w)
-	e.Indent("", "  ")
-	if err := e.EncodeToken(start); err != nil {
-		return err
-	}
-
-	sitemap := Url{}
+	abortWriter.Write(indexHeader)
 	for i := 0; i < nfiles; i++ {
-		sitemap.Loc = in.GetUrlsetUrl(i)
-		if err := e.Encode(sitemap); err != nil {
-			return err
-		}
+		s.writeXmlUrlLoc(&abortWriter, in.GetUrlsetUrl(i))
 	}
+	abortWriter.Write(indexFooter)
 
-	if err := e.EncodeToken(start.End()); err != nil {
-		return err
-	}
-
-	return e.Flush()
+	return abortWriter.firstErr
 }
 
 // writeUrlsetFile writes a single Sitemap Urlset file for the first 50K entries
 // in the given input.
-func writeUrlsetFile(w io.Writer, in Input) (retErr error) {
-	start := xml.StartElement{
-		Name: xml.Name{Local: "urlset"},
-		Attr: []xml.Attr{
-			{
-				Name:  xml.Name{Local: "xmlns"},
-				Value: "http://www.sitemaps.org/schemas/sitemap/0.9",
-			},
-			{
-				Name:  xml.Name{Local: "xmlns:image"},
-				Value: "http://www.google.com/schemas/sitemap-image/1.1",
-			},
-		},
-	}
+func (s *sitemapWriter) writeUrlsetFile(w io.Writer, in Input) error {
+	abortWriter := abortWriter{underlying: w}
+	var capErr error
 
-	if _, err := io.WriteString(w, xml.Header); err != nil {
-		return err
-	}
-
-	e := xml.NewEncoder(w)
-	e.Indent("", "  ")
-	if err := e.EncodeToken(start); err != nil {
-		return err
-	}
-
-	url := Url{}
-	image := Image{}
-	var count int
-	for in.HasNext() {
+	abortWriter.Write(urlsetHeader)
+	for count := 0; in.HasNext(); count++ {
 		if count >= maxSitemapCap {
-			retErr = errMaxCapReached{}
+			capErr = errMaxCapReached{}
 			break
 		}
 
-		entry := in.Next()
+		s.writeXmlUrlEntry(&abortWriter, in.Next())
+	}
+	abortWriter.Write(urlsetFooter)
 
-		url.Loc = entry.GetLoc()
-		url.LastMod = t2str(entry.GetLastMod())
-		url.Images = []Image{}
-		for _, imageUrl := range entry.GetImages() {
-			image.Loc = imageUrl
-			url.Images = append(url.Images, image)
+	if abortWriter.firstErr != nil {
+		return abortWriter.firstErr
+	}
+
+	return capErr
+}
+
+func (s *sitemapWriter) writeXmlUrlEntry(w io.Writer, e UrlEntry) {
+	loc := e.GetLoc()
+	lastMod := t2str(e.GetLastMod())
+	images := e.GetImages()
+	if lastMod == "" && len(images) == 0 {
+		// fast path
+		s.writeXmlUrlLoc(w, loc)
+		return
+	}
+
+	w.Write(tagUrlOpen)
+	w.Write(tagLocOpen)
+	s.writeXmlString(w, loc)
+	w.Write(tagLocClose)
+	if lastMod != "" {
+		w.Write(tagLastmodOpen)
+		s.writeXmlString(w, lastMod)
+		w.Write(tagLastmodClose)
+	}
+	if len(images) > 0 {
+		for i := range images {
+			w.Write(tagImageOpen)
+			s.writeXmlString(w, images[i])
+			w.Write(tagImageClose)
 		}
+	}
+	w.Write(tagUrlClose)
+}
 
-		if err := e.Encode(url); err != nil {
-			return err
-		}
+func (s *sitemapWriter) writeXmlUrlLoc(w io.Writer, loc string) {
+	w.Write(tagUrlOpen)
+	w.Write(tagLocOpen)
+	s.writeXmlString(w, loc)
+	w.Write(tagLocClose)
+	w.Write(tagUrlClose)
+}
 
-		count++
+func (s *sitemapWriter) writeXmlString(w io.Writer, str string) {
+	xml.EscapeText(w, []byte(str))
+}
+
+// Below are constant strings converted to byte slices ahead of time
+// to avoid run-time allocations caused by string to byte slice conversions.
+var (
+	indexHeader = []byte(xml.Header +
+		`<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` +
+		"\n",
+	)
+	indexFooter = []byte("</sitemapindex>")
+
+	urlsetHeader = []byte(xml.Header +
+		`<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">` +
+		"\n",
+	)
+	urlsetFooter = []byte(`</urlset>`)
+
+	tagUrlOpen      = []byte("  <url>\n")
+	tagUrlClose     = []byte("  </url>\n")
+	tagLocOpen      = []byte("    <loc>")
+	tagLocClose     = []byte("</loc>\n")
+	tagLastmodOpen  = []byte("    <lastmod>")
+	tagLastmodClose = []byte("</lastmod>\n")
+	tagImageOpen    = []byte("    <image:image>\n      <image:loc>")
+	tagImageClose   = []byte("</image:loc>\n    </image:image>\n")
+)
+
+type abortWriter struct {
+	underlying io.Writer
+	firstErr   error
+}
+
+func (w *abortWriter) Write(p []byte) (n int, err error) {
+	if w.firstErr != nil {
+		return 0, w.firstErr
 	}
 
-	if err := e.EncodeToken(start.End()); err != nil {
-		return err
+	n, err = w.underlying.Write(p)
+	if err != nil {
+		w.firstErr = err
 	}
-
-	if err := e.Flush(); err != nil {
-		return err
-	}
-
-	return retErr
+	return
 }
 
 const (

--- a/sitemap_test.go
+++ b/sitemap_test.go
@@ -84,7 +84,8 @@ func TestWriteAll(t *testing.T) {
 		Ω(out.sitemaps).Should(HaveLen(1))
 		Ω(out.sitemaps[0].String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"></urlset>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+</urlset>
 		`)))
 	})
 
@@ -274,19 +275,21 @@ func TestWriteAll(t *testing.T) {
 	})
 }
 
-func TestWriteUrlsetFile(t *testing.T) {
+func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		RegisterTestingT(t)
 
+		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(writeUrlsetFile(&out, &arrayInput{})).Should(BeNil())
+		Ω(s.writeUrlsetFile(&out, &arrayInput{})).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"></urlset>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+</urlset>
 		`)))
 
 		out.Reset()
-		Ω(writeUrlsetFile(&out, &arrayInput{Arr: []simpleEntry{{}, {}, {}, {}}})).Should(BeNil())
+		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: []simpleEntry{{}, {}, {}, {}}})).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -324,8 +327,9 @@ func TestWriteUrlsetFile(t *testing.T) {
 			},
 		}
 
+		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(writeUrlsetFile(&out, &arrayInput{Arr: entries})).Should(BeNil())
+		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries})).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -354,8 +358,9 @@ func TestWriteUrlsetFile(t *testing.T) {
 			{},
 		}
 
+		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(writeUrlsetFile(&out, &arrayInput{Arr: entries})).Should(BeNil())
+		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries})).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -383,7 +388,7 @@ func TestWriteUrlsetFile(t *testing.T) {
 		}
 
 		out.Reset()
-		Ω(writeUrlsetFile(&out, &arrayInput{Arr: entries})).Should(BeNil())
+		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries})).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -431,8 +436,9 @@ func TestWriteUrlsetFile(t *testing.T) {
 			},
 		}
 
+		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(writeUrlsetFile(&out, &arrayInput{Arr: entries})).Should(BeNil())
+		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries})).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -465,7 +471,8 @@ func TestWriteUrlsetFile(t *testing.T) {
 				Size: 50_000 + 1,
 			}
 
-			Ω(writeUrlsetFile(ioutil.Discard, &in)).
+			var s sitemapWriter
+			Ω(s.writeUrlsetFile(ioutil.Discard, &in)).
 				Should(MatchError("max 50K capacity is reached"))
 		})
 
@@ -481,13 +488,14 @@ func TestWriteUrlsetFile(t *testing.T) {
 				Size: 50_000 + 1,
 			}
 
-			Ω(writeUrlsetFile(&failingWriter{}, &in)).
+			var s sitemapWriter
+			Ω(s.writeUrlsetFile(&failingWriter{}, &in)).
 				Should(MatchError("failingWriter error"))
 		})
 	})
 }
 
-func TestWriteIndexFile(t *testing.T) {
+func TestSitemapWriter_WriteIndexFile(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		RegisterTestingT(t)
 
@@ -495,19 +503,22 @@ func TestWriteIndexFile(t *testing.T) {
 			return ""
 		}
 
+		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(writeIndexFile(&out, &arrayInput{CustomUrlsetUrl: emptyUrl}, 0)).Should(BeNil())
+		Ω(s.writeIndexFile(&out, &arrayInput{CustomUrlsetUrl: emptyUrl}, 0)).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></sitemapindex>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+</sitemapindex>
 		`)))
 	})
 
 	t.Run("default", func(t *testing.T) {
 		RegisterTestingT(t)
 
+		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(writeIndexFile(&out, &arrayInput{}, 3)).Should(BeNil())
+		Ω(s.writeIndexFile(&out, &arrayInput{}, 3)).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -531,8 +542,9 @@ func TestWriteIndexFile(t *testing.T) {
 			return fmt.Sprintf("custom @%03d@", idx)
 		}
 
+		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(writeIndexFile(&out, &arrayInput{CustomUrlsetUrl: simpleUrl}, 4)).Should(BeNil())
+		Ω(s.writeIndexFile(&out, &arrayInput{CustomUrlsetUrl: simpleUrl}, 4)).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -568,8 +580,9 @@ func TestWriteIndexFile(t *testing.T) {
 			}
 		}
 
+		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(writeIndexFile(&out, &arrayInput{CustomUrlsetUrl: fancyUrl}, 5)).Should(BeNil())
+		Ω(s.writeIndexFile(&out, &arrayInput{CustomUrlsetUrl: fancyUrl}, 5)).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -602,7 +615,8 @@ func TestWriteIndexFile(t *testing.T) {
 				},
 			}
 
-			Ω(writeIndexFile(&failingWriter{}, &in, 100)).
+			var s sitemapWriter
+			Ω(s.writeIndexFile(&failingWriter{}, &in, 100)).
 				Should(MatchError("failingWriter error"))
 		})
 	})
@@ -773,6 +787,7 @@ func BenchmarkWriteUrlset(b *testing.B) {
 			return "const url"
 		},
 	}
+	var s sitemapWriter
 
 	for p := 0; p < 7; p++ {
 		size := int(math.Pow10(p))
@@ -780,7 +795,7 @@ func BenchmarkWriteUrlset(b *testing.B) {
 			in.Size = size
 			for n := 0; n < b.N; n++ {
 				in.Reset()
-				_ = writeUrlsetFile(ioutil.Discard, &in)
+				_ = s.writeUrlsetFile(ioutil.Discard, &in)
 			}
 		})
 	}
@@ -797,13 +812,14 @@ func BenchmarkWriteIndex(b *testing.B) {
 			return "const url"
 		},
 	}
+	var s sitemapWriter
 
 	for p := 0; p < 6; p++ {
 		nfiles := int(math.Pow10(p))
 		b.Run(strconv.Itoa(nfiles), func(b *testing.B) {
 			for n := 0; n < b.N; n++ {
 				in.Reset()
-				_ = writeIndexFile(ioutil.Discard, &in, nfiles)
+				_ = s.writeIndexFile(ioutil.Discard, &in, nfiles)
 			}
 		})
 	}


### PR DESCRIPTION
This PR reduces the memory allocation performed by this library, and makes it independent of the input length, `O(1)`.

This was possible due to the following changes:
- Convert all XML code to constant strings (https://github.com/PlanitarInc/go-sitemap/pull/14/commits/26ee6421a425b6e9b3eb68f6d8ecc996499962b8). All the XML code (tags and attributes) is known ahead of time so there is no need to render it using `xml.Encoder`.
- Convert all constant string to byte slices ahead of time (https://github.com/PlanitarInc/go-sitemap/pull/14/commits/26ee6421a425b6e9b3eb68f6d8ecc996499962b8). When rendering an XML file to `io.Writer` we need to write a slice of bytes rather than a string. Converting a string to a byte slice results in an allocation because GO strings are immutable.
- Use a temporary buffer for rendering dynamic string values to XML (https://github.com/PlanitarInc/go-sitemap/pull/14/commits/fa7179a4989b190b1ab885c363e25210b244b37b). Again, this is needed to remove the allocation made when converting a string to a slice of bytes.
- Use a temporary buffer for rendering time values to XML (https://github.com/PlanitarInc/go-sitemap/pull/14/commits/d4da84f85b0a91a589e08274c2c26042b275e309). This approach is a bit tricky. We rely on 2 facts: (a) the final serialized time string will have the same length as the `time.RFC3339` format string, (b) `time.AppendFormat()` is trying to reuse the passed slice of bytes for rendering a string. The approach is to pre-allocate enough space in the temporary buffer and to pass the byte slice of this buffer to `AppendFormat()`. In case any of the stated 2 assumptions is broken, the code will continue work as expected but it won't be "alloc-free".
- Use struct for `UrlEntry` type (https://github.com/PlanitarInc/go-sitemap/pull/14/commits/53dd41cbad2c165bd1620689c069298227584d9b). This is needed to remove the allocation made for "boxing" a concrete entry type (defined by an application) into library's `UrlEntry` interface upon every call of `Input.Next()`.

By applying these changes we've made the library almost "alloc-free". The allocations now depend on `UrlEntry.Loc` https://github.com/PlanitarInc/go-sitemap/blob/53dd41cbad2c165bd1620689c069298227584d9b/interfaces.go#L14-L15 rather on the length of input. Side note: a carefully designed input can cause this library to allocate for every rendered entry but this should not really happen in practice.

On the way, this PR introduces `abortWriter` to simplify the code. This writer type is a wrapper for a writer, all it is doing is pretty much recording the first writing error. 


### Benchmarks

The outcome of these changes is that the library is running at least 60% faster.

```
$ go test -run '^$' -bench . -benchmem
goos: darwin
goarch: amd64
pkg: github.com/PlanitarInc/go-sitemap
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkWriteAll/1-12                      	 1323837	       920.8 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/10-12                     	  174440	      6726 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/100-12                    	   18532	     65129 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/1000-12                   	    1855	    640370 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/10000-12                  	     168	   7395119 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/100000-12                 	      16	  65864465 ns/op	     160 B/op	       4 allocs/op
BenchmarkWriteAll/1000000-12                	       2	 747052939 ns/op	     736 B/op	      22 allocs/op
BenchmarkWriteUrlset/1-12                   	 1398517	       849.3 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/10-12                  	  181693	      6681 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/100-12                 	   16810	     73855 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/1000-12                	    1707	    681426 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/10000-12               	     168	   7014104 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/100000-12              	      32	  35761613 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/1000000-12             	      36	  32433611 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/1-12                    	 9478348	       127.2 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/10-12                   	 1214608	       894.0 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/100-12                  	  140778	      8384 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/1000-12                 	   14365	     82711 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/10000-12                	    1311	    859726 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/100000-12               	     141	   8356007 ns/op	      32 B/op	       1 allocs/op
BenchmarkSitemapWriter_writeXmlString/short-12         	31168033	        37.79 ns/op	       0 B/op	       0 allocs/op
BenchmarkSitemapWriter_writeXmlString/long-12          	 5605268	       209.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkSitemapWriter_writeXmlTime/utc-12             	 5869622	       205.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkSitemapWriter_writeXmlTime/custom-12          	 5462307	       221.6 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/PlanitarInc/go-sitemap	39.145s
```

Diff with master:

```
$ benchcmp old.bench new.bench
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                           old ns/op      new ns/op     delta
BenchmarkWriteAll/1-12              5811           921           -84.15%
BenchmarkWriteAll/10-12             23392          6726          -71.25%
BenchmarkWriteAll/100-12            198466         65129         -67.18%
BenchmarkWriteAll/1000-12           1952371        640370        -67.20%
BenchmarkWriteAll/10000-12          19451444       7395119       -61.98%
BenchmarkWriteAll/100000-12         194844889      65864465      -66.20%
BenchmarkWriteAll/1000000-12        1938904848     747052939     -61.47%
BenchmarkWriteUrlset/1-12           3711           849           -77.11%
BenchmarkWriteUrlset/10-12          21358          6681          -68.72%
BenchmarkWriteUrlset/100-12         195381         73855         -62.20%
BenchmarkWriteUrlset/1000-12        1943058        681426        -64.93%
BenchmarkWriteUrlset/10000-12       21040814       7014104       -66.66%
BenchmarkWriteUrlset/100000-12      101490329      35761613      -64.76%
BenchmarkWriteUrlset/1000000-12     96949476       32433611      -66.55%
BenchmarkWriteIndex/1-12            1912           127           -93.35%
BenchmarkWriteIndex/10-12           6545           894           -86.34%
BenchmarkWriteIndex/100-12          51513          8384          -83.72%
BenchmarkWriteIndex/1000-12         513240         82711         -83.88%
BenchmarkWriteIndex/10000-12        5323145        859726        -83.85%
BenchmarkWriteIndex/100000-12       60147152       8356007       -86.11%

benchmark                           old allocs     new allocs     delta
BenchmarkWriteAll/1-12              25             3              -88.00%
BenchmarkWriteAll/10-12             61             3              -95.08%
BenchmarkWriteAll/100-12            421            3              -99.29%
BenchmarkWriteAll/1000-12           4021           3              -99.93%
BenchmarkWriteAll/10000-12          40021          3              -99.99%
BenchmarkWriteAll/100000-12         400032         4              -100.00%
BenchmarkWriteAll/1000000-12        4000235        22             -100.00%
BenchmarkWriteUrlset/1-12           14             1              -92.86%
BenchmarkWriteUrlset/10-12          50             1              -98.00%
BenchmarkWriteUrlset/100-12         410            1              -99.76%
BenchmarkWriteUrlset/1000-12        4010           1              -99.98%
BenchmarkWriteUrlset/10000-12       40010          1              -100.00%
BenchmarkWriteUrlset/100000-12      200010         1              -100.00%
BenchmarkWriteUrlset/1000000-12     200010         1              -100.00%
BenchmarkWriteIndex/1-12            11             1              -90.91%
BenchmarkWriteIndex/10-12           20             1              -95.00%
BenchmarkWriteIndex/100-12          110            1              -99.09%
BenchmarkWriteIndex/1000-12         1010           1              -99.90%
BenchmarkWriteIndex/10000-12        10010          1              -99.99%
BenchmarkWriteIndex/100000-12       100010         1              -100.00%

benchmark                           old bytes     new bytes     delta
BenchmarkWriteAll/1-12              9720          128           -98.68%
BenchmarkWriteAll/10-12             11520         128           -98.89%
BenchmarkWriteAll/100-12            29520         128           -99.57%
BenchmarkWriteAll/1000-12           209520        128           -99.94%
BenchmarkWriteAll/10000-12          2009520       128           -99.99%
BenchmarkWriteAll/100000-12         20014352      160           -100.00%
BenchmarkWriteAll/1000000-12        200101720     736           -100.00%
BenchmarkWriteUrlset/1-12           4936          32            -99.35%
BenchmarkWriteUrlset/10-12          6736          32            -99.52%
BenchmarkWriteUrlset/100-12         24736         32            -99.87%
BenchmarkWriteUrlset/1000-12        204736        32            -99.98%
BenchmarkWriteUrlset/10000-12       2004737       32            -100.00%
BenchmarkWriteUrlset/100000-12      10004752      32            -100.00%
BenchmarkWriteUrlset/1000000-12     10004736      32            -100.00%
BenchmarkWriteIndex/1-12            4784          32            -99.33%
BenchmarkWriteIndex/10-12           5648          32            -99.43%
BenchmarkWriteIndex/100-12          14288         32            -99.78%
BenchmarkWriteIndex/1000-12         100688        32            -99.97%
BenchmarkWriteIndex/10000-12        964689        32            -100.00%
BenchmarkWriteIndex/100000-12       9604693       32            -100.00%
```