### PR TITLE
Fix losing the 1st one element on the next chunk

### DIFF
--- a/sitemap.go
+++ b/sitemap.go
@@ -54,12 +54,14 @@ func (s *sitemapWriter) writeUrlsetFile(w io.Writer, in Input) error {
 	var capErr error
 
 	_, _ = abortWriter.Write(urlsetHeader)
-	for count := 0; in.HasNext(); count++ {
+	for count := 0; ; count++ {
 		if count >= maxSitemapCap {
 			capErr = errMaxCapReached{}
 			break
 		}
-
+		if !in.HasNext() {
+			break
+		}
 		s.writeXmlUrlEntry(&abortWriter, in.Next())
 	}
 	_, _ = abortWriter.Write(urlsetFooter)


### PR DESCRIPTION
This PR fixes losing the 1st one element on the next chunk. Previously, for example, if the total element is 60K, it is actually divided into 50,000 and 9,999. The first element of the second chunk is lost.

Related to https://github.com/PlanitarInc/go-sitemap/pull/14
Related to https://github.com/PlanitarInc/walk-inside-api/pull/992
Related to https://planitar.atlassian.net/browse/PRTL-359