### PR TITLE
Fix generation of multi-file sitemaps for ChannelInput

### DIFF
--- a/channel-input_test.go
+++ b/channel-input_test.go
@@ -132,48 +132,108 @@ func TestChannelInput_GetUrlsetUrl(t *testing.T) {
 }
 
 func TestWriteAll_ChannelInput(t *testing.T) {
-	RegisterTestingT(t)
+	t.Run("simple", func(t *testing.T) {
+		RegisterTestingT(t)
 
-	var out bufferOuput
-	in := NewChannelInput(func(idx int) string {
-		return fmt.Sprintf("channel input urlset %d", idx)
+		var out bufferOuput
+		in := NewChannelInput(func(idx int) string {
+			return fmt.Sprintf("channel input urlset %d", idx)
+		})
+
+		go func(in *ChannelInput) {
+			in.Feed(&UrlEntry{Loc: "a"})
+			in.Feed(&UrlEntry{Loc: "b"})
+			in.Feed(&UrlEntry{Loc: "c"})
+			in.Close()
+		}(in)
+
+		Ω(WriteAll(&out, in)).Should(BeNil())
+
+		Ω(out.index.String()).Should(MatchXML(`
+			<?xml version="1.0" encoding="UTF-8"?>
+			<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+			  <url>
+				<loc>channel input urlset 0</loc>
+			  </url>
+			</sitemapindex>
+		`))
+
+		Ω(out.sitemaps).Should(HaveLen(1))
+		Ω(out.sitemaps[0].String()).Should(MatchXML(`
+			<?xml version="1.0" encoding="UTF-8"?>
+			<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+				xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+				<url> <loc>a</loc> </url>
+				<url> <loc>b</loc> </url>
+				<url> <loc>c</loc> </url>
+			</urlset>
+		`))
 	})
 
-	go func(in *ChannelInput) {
-		in.Feed(&UrlEntry{Loc: "a"})
-	}(in)
-	go func(in *ChannelInput) {
-		time.Sleep(100 * time.Millisecond)
-		in.Feed(&UrlEntry{Loc: "b"})
-	}(in)
-	go func(in *ChannelInput) {
-		time.Sleep(200 * time.Millisecond)
-		in.Feed(&UrlEntry{Loc: "c"})
-	}(in)
-	go func(in *ChannelInput) {
-		time.Sleep(500 * time.Millisecond)
-		in.Close()
-	}(in)
+	t.Run("concurrent", func(t *testing.T) {
+		RegisterTestingT(t)
 
-	Ω(WriteAll(&out, in)).Should(BeNil())
+		var out bufferOuput
+		in := NewChannelInput(func(idx int) string {
+			return fmt.Sprintf("channel input urlset %d", idx)
+		})
 
-	Ω(out.index.String()).Should(MatchXML(`
-<?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>channel input urlset 0</loc>
-  </url>
-</sitemapindex>
-	`))
+		go func(in *ChannelInput) {
+			in.Feed(&UrlEntry{Loc: "a"})
+		}(in)
+		go func(in *ChannelInput) {
+			time.Sleep(100 * time.Millisecond)
+			in.Feed(&UrlEntry{Loc: "b"})
+		}(in)
+		go func(in *ChannelInput) {
+			time.Sleep(200 * time.Millisecond)
+			in.Feed(&UrlEntry{Loc: "c"})
+		}(in)
+		go func(in *ChannelInput) {
+			time.Sleep(500 * time.Millisecond)
+			in.Close()
+		}(in)
 
-	Ω(out.sitemaps).Should(HaveLen(1))
-	Ω(out.sitemaps[0].String()).Should(MatchXML(`
-		<?xml version="1.0" encoding="UTF-8"?>
-		<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-			xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
-			<url> <loc>a</loc> </url>
-			<url> <loc>b</loc> </url>
-			<url> <loc>c</loc> </url>
-		</urlset>
-	`))
+		Ω(WriteAll(&out, in)).Should(BeNil())
+
+		Ω(out.index.String()).Should(MatchXML(`
+			<?xml version="1.0" encoding="UTF-8"?>
+			<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+			  <url>
+				<loc>channel input urlset 0</loc>
+			  </url>
+			</sitemapindex>
+		`))
+
+		Ω(out.sitemaps).Should(HaveLen(1))
+		Ω(out.sitemaps[0].String()).Should(MatchXML(`
+			<?xml version="1.0" encoding="UTF-8"?>
+			<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+				xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+				<url> <loc>a</loc> </url>
+				<url> <loc>b</loc> </url>
+				<url> <loc>c</loc> </url>
+			</urlset>
+		`))
+	})
+
+	t.Run("multiplePages", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		inputSize := 58_765
+		var out bufferOuput
+		in := NewChannelInput(func(idx int) string {
+			return fmt.Sprintf("urlset %03d", idx)
+		})
+
+		go func(in *ChannelInput) {
+			for i := 0; i < inputSize; i++ {
+				in.Feed(&UrlEntry{Loc: fmt.Sprintf("http://goiguide.com/%d", i+1)})
+			}
+			in.Close()
+		}(in)
+
+		Ω(WriteAll(&out, in)).Should(BeNil())
+		assertOutput(&out, inputSize)
+	})
 }

--- a/sitemap_test.go
+++ b/sitemap_test.go
@@ -441,7 +441,7 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 
 		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(s.writeUrlsetFile(&out, &arrayInput{})).Should(BeNil())
+		Ω(s.writeUrlsetFile(&out, &arrayInput{}, false)).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -449,7 +449,7 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 		`)))
 
 		out.Reset()
-		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: []UrlEntry{{}, {}, {}, {}}})).Should(BeNil())
+		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: []UrlEntry{{}, {}, {}, {}}}, false)).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -489,7 +489,7 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 
 		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries})).Should(BeNil())
+		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries}, false)).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -520,7 +520,7 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 
 		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries})).Should(BeNil())
+		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries}, false)).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -548,7 +548,7 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 		}
 
 		out.Reset()
-		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries})).Should(BeNil())
+		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries}, false)).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -598,7 +598,7 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 
 		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries})).Should(BeNil())
+		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries}, false)).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -632,7 +632,7 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 			}
 
 			var s sitemapWriter
-			Ω(s.writeUrlsetFile(ioutil.Discard, &in)).
+			Ω(s.writeUrlsetFile(ioutil.Discard, &in, false)).
 				Should(MatchError("max 50K capacity is reached"))
 		})
 
@@ -649,7 +649,7 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 			}
 
 			var s sitemapWriter
-			Ω(s.writeUrlsetFile(&failingWriter{}, &in)).
+			Ω(s.writeUrlsetFile(&failingWriter{}, &in, false)).
 				Should(MatchError("failingWriter error"))
 		})
 	})
@@ -979,7 +979,7 @@ func BenchmarkWriteUrlset(b *testing.B) {
 			in.Size = size
 			for n := 0; n < b.N; n++ {
 				in.Reset()
-				_ = s.writeUrlsetFile(ioutil.Discard, &in)
+				_ = s.writeUrlsetFile(ioutil.Discard, &in, false)
 			}
 		})
 	}


### PR DESCRIPTION
The current implementation, https://github.com/PlanitarInc/go-sitemap/pull/12, for supporting >50K entries has a bug: it assumes that the input implementation "advances" itself when its `Next()` method is called. This assumption is wrong. Even the `ChannelInput` type exported by this package violates it. That is, it advances itself when the `HasNext()` method is called.

The result of this bug is a lost entry for inputs that advance their internal state in `HasNext()`. A good example of such case is `ChannelInput`.

This PR fixes it. It ensures that `HasNext()` and `Next()` are called exactly once for every entry. `HasNext()` is called an additional time to ensure the iteration is over. That is, `WriteAll` will call `HasNext()` exactly N+1 times and call `Next()` exactly N times for an input with N entries. Of course, the calls of `HasNext` and `Next` alternate: HasNext, Next, HasNext, Next, ...

### Benchmarks

The benchmarks show more or less the same results. No change in allocs. Runtime change varies from -5% to -20% but I think this result is not significant enough to trust it.

```
 $ go test -run '^$' -bench . -benchmem | tee new.bench
goos: darwin
goarch: amd64
pkg: github.com/PlanitarInc/go-sitemap
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkWriteAll/1-12                      	 1339442	       890.4 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/10-12                     	  178462	      6606 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/100-12                    	   18696	     63392 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/1000-12                   	    1867	    646886 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/10000-12                  	     189	   6316539 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/100000-12                 	      18	  63653469 ns/op	     160 B/op	       4 allocs/op
BenchmarkWriteAll/1000000-12                	       2	 638899862 ns/op	     736 B/op	      22 allocs/op
BenchmarkWriteUrlset/1-12                   	 1718119	       691.5 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/10-12                  	  184988	      6365 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/100-12                 	   19137	     63601 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/1000-12                	    1892	    631901 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/10000-12               	     190	   6637826 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/100000-12              	      36	  31277780 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/1000000-12             	      37	  31438372 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/1-12                    	 9523932	       126.4 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/10-12                   	 1347334	       871.3 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/100-12                  	  139867	      8250 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/1000-12                 	   14689	     81698 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/10000-12                	    1411	    818067 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/100000-12               	     146	   8217140 ns/op	      32 B/op	       1 allocs/op
BenchmarkSitemapWriter_writeXmlString/short-12         	32231965	        36.28 ns/op	       0 B/op	       0 allocs/op
BenchmarkSitemapWriter_writeXmlString/long-12          	 5748565	       208.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkSitemapWriter_writeXmlTime/utc-12             	 5838555	       208.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkSitemapWriter_writeXmlTime/custom-12          	 4966195	       221.8 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/PlanitarInc/go-sitemap	37.547s
```

Comparison to master:

```
$ benchcmp old.bench new.bench
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                          old ns/op     new ns/op     delta
BenchmarkWriteAll/1-12                             966           890           -7.83%
BenchmarkWriteAll/10-12                            7404          6606          -10.78%
BenchmarkWriteAll/100-12                           84750         63392         -25.20%
BenchmarkWriteAll/1000-12                          822508        646886        -21.35%
BenchmarkWriteAll/10000-12                         7210228       6316539       -12.39%
BenchmarkWriteAll/100000-12                        73317026      63653469      -13.18%
BenchmarkWriteAll/1000000-12                       695820800     638899862     -8.18%
BenchmarkWriteUrlset/1-12                          909           692           -23.89%
BenchmarkWriteUrlset/10-12                         8215          6365          -22.52%
BenchmarkWriteUrlset/100-12                        76855         63601         -17.25%
BenchmarkWriteUrlset/1000-12                       745129        631901        -15.20%
BenchmarkWriteUrlset/10000-12                      7530459       6637826       -11.85%
BenchmarkWriteUrlset/100000-12                     40530718      31277780      -22.83%
BenchmarkWriteUrlset/1000000-12                    38309880      31438372      -17.94%
BenchmarkWriteIndex/1-12                           167           126           -24.40%
BenchmarkWriteIndex/10-12                          1155          871           -24.56%
BenchmarkWriteIndex/100-12                         10980         8250          -24.86%
BenchmarkWriteIndex/1000-12                        97846         81698         -16.50%
BenchmarkWriteIndex/10000-12                       985195        818067        -16.96%
BenchmarkWriteIndex/100000-12                      10004047      8217140       -17.86%
BenchmarkSitemapWriter_writeXmlString/short-12     45.6          36.3          -20.40%
BenchmarkSitemapWriter_writeXmlString/long-12      259           209           -19.26%
BenchmarkSitemapWriter_writeXmlTime/utc-12         249           208           -16.57%
BenchmarkSitemapWriter_writeXmlTime/custom-12      277           222           -19.99%

benchmark                                          old allocs     new allocs     delta
BenchmarkWriteAll/1-12                             3              3              +0.00%
BenchmarkWriteAll/10-12                            3              3              +0.00%
BenchmarkWriteAll/100-12                           3              3              +0.00%
BenchmarkWriteAll/1000-12                          3              3              +0.00%
BenchmarkWriteAll/10000-12                         3              3              +0.00%
BenchmarkWriteAll/100000-12                        4              4              +0.00%
BenchmarkWriteAll/1000000-12                       22             22             +0.00%
BenchmarkWriteUrlset/1-12                          1              1              +0.00%
BenchmarkWriteUrlset/10-12                         1              1              +0.00%
BenchmarkWriteUrlset/100-12                        1              1              +0.00%
BenchmarkWriteUrlset/1000-12                       1              1              +0.00%
BenchmarkWriteUrlset/10000-12                      1              1              +0.00%
BenchmarkWriteUrlset/100000-12                     1              1              +0.00%
BenchmarkWriteUrlset/1000000-12                    1              1              +0.00%
BenchmarkWriteIndex/1-12                           1              1              +0.00%
BenchmarkWriteIndex/10-12                          1              1              +0.00%
BenchmarkWriteIndex/100-12                         1              1              +0.00%
BenchmarkWriteIndex/1000-12                        1              1              +0.00%
BenchmarkWriteIndex/10000-12                       1              1              +0.00%
BenchmarkWriteIndex/100000-12                      1              1              +0.00%
BenchmarkSitemapWriter_writeXmlString/short-12     0              0              +0.00%
BenchmarkSitemapWriter_writeXmlString/long-12      0              0              +0.00%
BenchmarkSitemapWriter_writeXmlTime/utc-12         0              0              +0.00%
BenchmarkSitemapWriter_writeXmlTime/custom-12      0              0              +0.00%

benchmark                                          old bytes     new bytes     delta
BenchmarkWriteAll/1-12                             128           128           +0.00%
BenchmarkWriteAll/10-12                            128           128           +0.00%
BenchmarkWriteAll/100-12                           128           128           +0.00%
BenchmarkWriteAll/1000-12                          128           128           +0.00%
BenchmarkWriteAll/10000-12                         128           128           +0.00%
BenchmarkWriteAll/100000-12                        160           160           +0.00%
BenchmarkWriteAll/1000000-12                       736           736           +0.00%
BenchmarkWriteUrlset/1-12                          32            32            +0.00%
BenchmarkWriteUrlset/10-12                         32            32            +0.00%
BenchmarkWriteUrlset/100-12                        32            32            +0.00%
BenchmarkWriteUrlset/1000-12                       32            32            +0.00%
BenchmarkWriteUrlset/10000-12                      32            32            +0.00%
BenchmarkWriteUrlset/100000-12                     32            32            +0.00%
BenchmarkWriteUrlset/1000000-12                    32            32            +0.00%
BenchmarkWriteIndex/1-12                           32            32            +0.00%
BenchmarkWriteIndex/10-12                          32            32            +0.00%
BenchmarkWriteIndex/100-12                         32            32            +0.00%
BenchmarkWriteIndex/1000-12                        32            32            +0.00%
BenchmarkWriteIndex/10000-12                       32            32            +0.00%
BenchmarkWriteIndex/100000-12                      32            32            +0.00%
BenchmarkSitemapWriter_writeXmlString/short-12     0             0             +0.00%
BenchmarkSitemapWriter_writeXmlString/long-12      0             0             +0.00%
BenchmarkSitemapWriter_writeXmlTime/utc-12         0             0             +0.00%
BenchmarkSitemapWriter_writeXmlTime/custom-12      0             0             +0.00%
```