### PR TITLE
Remove `Input.HasNext()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A GO library for generating Sitemap XML files.
 
 ### Example
 
-GO Playground: https://play.golang.org/p/PTYJXlJt8ep
+<!-- GO Playground: https://play.golang.org/p/PTYJXlJt8ep -->
 
 ```go
 package main
@@ -38,14 +38,13 @@ type ArrayInput struct {
 	nextIdx int
 }
 
-func (a ArrayInput) HasNext() bool {
-	return a.nextIdx < len(a.Arr)
-}
-
 func (a *ArrayInput) Next() *sitemap.UrlEntry {
-	idx := a.nextIdx
+	if a.nextIdx >= len(a.Arr) {
+		return nil
+	}
+
 	a.nextIdx++
-	return &a.Arr[idx]
+	return &a.Arr[a.nextIdx-1]
 }
 
 func (a *ArrayInput) GetUrlsetUrl(n int) string {
@@ -130,11 +129,11 @@ goos: darwin
 goarch: amd64
 pkg: github.com/PlanitarInc/go-sitemap
 cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-BenchmarkWriteAll/1-12                      	 1315534	       905.3 ns/op	     128 B/op	       3 allocs/op
-BenchmarkWriteAll/10-12                     	  176637	      6779 ns/op	     128 B/op	       3 allocs/op
-BenchmarkWriteAll/100-12                    	   18620	     64473 ns/op	     128 B/op	       3 allocs/op
-BenchmarkWriteAll/1000-12                   	    1846	    639137 ns/op	     128 B/op	       3 allocs/op
-BenchmarkWriteAll/10000-12                  	     186	   6436503 ns/op	     128 B/op	       3 allocs/op
-BenchmarkWriteAll/100000-12                 	      18	  64117438 ns/op	     160 B/op	       4 allocs/op
-BenchmarkWriteAll/1000000-12                	       2	 642308146 ns/op	     736 B/op	      22 allocs/op
+BenchmarkWriteAll/1-12                      	 1328336	       945.2 ns/op	     128 B/op	       3 allocs/op
+BenchmarkWriteAll/10-12                     	  150031	      6808 ns/op	     128 B/op	       3 allocs/op
+BenchmarkWriteAll/100-12                    	   17624	     62340 ns/op	     128 B/op	       3 allocs/op
+BenchmarkWriteAll/1000-12                   	    1898	    627547 ns/op	     128 B/op	       3 allocs/op
+BenchmarkWriteAll/10000-12                  	     192	   6315018 ns/op	     128 B/op	       3 allocs/op
+BenchmarkWriteAll/100000-12                 	      18	  62742897 ns/op	     160 B/op	       4 allocs/op
+BenchmarkWriteAll/1000000-12                	       2	 632302752 ns/op	     736 B/op	      22 allocs/op
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -202,14 +202,13 @@ type arrayInput struct {
 	nextIdx int
 }
 
-func (a arrayInput) HasNext() bool {
-	return a.nextIdx < len(a.Arr)
-}
-
 func (a *arrayInput) Next() *sitemap.UrlEntry {
-	idx := a.nextIdx
+	if a.nextIdx >= len(a.Arr) {
+		return nil
+	}
+
 	a.nextIdx++
-	return &a.Arr[idx]
+	return &a.Arr[a.nextIdx-1]
 }
 
 func (a *arrayInput) GetUrlsetUrl(n int) string {
@@ -222,11 +221,11 @@ type dynamicInput struct {
 	entry   sitemap.UrlEntry
 }
 
-func (d dynamicInput) HasNext() bool {
-	return d.nextIdx < d.Length
-}
-
 func (d *dynamicInput) Next() *sitemap.UrlEntry {
+	if d.nextIdx >= d.Length {
+		return nil
+	}
+
 	idx := d.nextIdx
 	d.nextIdx++
 	d.entry.Loc = fmt.Sprintf("https://goiguide.com/entry-%05d", idx)

--- a/interfaces.go
+++ b/interfaces.go
@@ -6,8 +6,10 @@ import (
 )
 
 type Input interface {
+	// Next returns the next UrlEntry to be written. The function should
+	// return nil if and only if there are no more items.
 	Next() *UrlEntry
-	HasNext() bool
+	// GetUrlsetUrl returns a URL for the Urlset file at the given index.
 	GetUrlsetUrl(idx int) string
 }
 

--- a/sitemap.go
+++ b/sitemap.go
@@ -3,7 +3,6 @@ package sitemap
 import (
 	"bytes"
 	"encoding/xml"
-	"errors"
 	"io"
 	"time"
 )
@@ -21,11 +20,11 @@ func WriteAll(o Output, in Input) error {
 		nfiles++
 		var err error
 		carryOverEntry, err = s.writeUrlsetFile(o.Urlset(), in, carryOverEntry)
-		if err != nil && !errors.Is(err, errMaxCapReached{}) {
+		if err != nil {
 			return err
 		}
 
-		if err == nil {
+		if carryOverEntry == nil {
 			return s.writeIndexFile(o.Index(), in, nfiles)
 		}
 	}
@@ -88,11 +87,7 @@ func (s *sitemapWriter) writeUrlsetFile(
 		return nil, abortWriter.firstErr
 	}
 
-	if carryOverEntry != nil {
-		return carryOverEntry, errMaxCapReached{}
-	}
-
-	return nil, nil
+	return carryOverEntry, nil
 }
 
 func (s *sitemapWriter) writeXmlUrlEntry(w io.Writer, e *UrlEntry) {
@@ -187,9 +182,3 @@ func (w *abortWriter) Write(p []byte) (n int, err error) {
 const (
 	maxSitemapCap = 50_000
 )
-
-type errMaxCapReached struct{}
-
-func (e errMaxCapReached) Error() string {
-	return "max 50K capacity is reached"
-}

--- a/sitemap_test.go
+++ b/sitemap_test.go
@@ -461,7 +461,7 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 
 			var s sitemapWriter
 			co, err := s.writeUrlsetFile(ioutil.Discard, &in, nil)
-			Ω(err).Should(MatchError("max 50K capacity is reached"))
+			Ω(err).Should(BeNil())
 			Ω(co).Should(Equal(&UrlEntry{
 				Loc:     "http://www.example.com/qweqwe",
 				LastMod: minDate.AddDate(1, 2, 3),

--- a/sitemap_test.go
+++ b/sitemap_test.go
@@ -82,6 +82,13 @@ func TestWriteAll(t *testing.T) {
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
+    <loc>http://goiguide.com/0</loc>
+    <lastmod>2001-03-04T00:00:00Z</lastmod>
+    <image:image>
+      <image:loc>http://youriguide.com/0.jpg</image:loc>
+    </image:image>
+  </url>
+  <url>
     <loc>http://goiguide.com/1</loc>
     <lastmod>2001-03-04T00:00:00Z</lastmod>
     <image:image>
@@ -95,15 +102,10 @@ func TestWriteAll(t *testing.T) {
       <image:loc>http://youriguide.com/2.jpg</image:loc>
     </image:image>
   </url>
-  <url>
-    <loc>http://goiguide.com/3</loc>
-    <lastmod>2001-03-04T00:00:00Z</lastmod>
-    <image:image>
-      <image:loc>http://youriguide.com/3.jpg</image:loc>
-    </image:image>
-  </url>
 </urlset>
 		`)))
+
+		assertOutput(&out, in.Size)
 	})
 
 	t.Run("maxSingleSitemap", func(t *testing.T) {
@@ -183,210 +185,18 @@ func TestWriteAll(t *testing.T) {
 		assertOutput(&out, in.Size)
 	})
 
-	t.Run("nextAdvances", func(t *testing.T) {
-		t.Run("inputInvariant", func(t *testing.T) {
-			RegisterTestingT(t)
+	t.Run("numeroursSitemaps", func(t *testing.T) {
+		RegisterTestingT(t)
 
-			in := dynamicInput{
-				Size:            3,
-				CustomEntry:     customEntry,
-				CustomUrlsetUrl: customUrl,
-			}
+		in := dynamicInput{
+			Size:            50_000*8 + 714,
+			CustomEntry:     customEntry,
+			CustomUrlsetUrl: customUrl,
+		}
+		var out bufferOuput
 
-			Ω(in.HasNextAdvances).Should(BeFalse())
-			Ω(in.HasNext()).Should(BeTrue())
-			Ω(in.nextIdx).Should(Equal(0))
-			Ω(in.HasNext()).Should(BeTrue())
-			Ω(in.nextIdx).Should(Equal(0))
-
-			Ω(in.Next()).ShouldNot(BeNil())
-			Ω(in.nextIdx).Should(Equal(1))
-			Ω(in.HasNext()).Should(BeTrue())
-			Ω(in.nextIdx).Should(Equal(1))
-			Ω(in.HasNext()).Should(BeTrue())
-			Ω(in.nextIdx).Should(Equal(1))
-		})
-
-		t.Run("shortSingleSitemap", func(t *testing.T) {
-			RegisterTestingT(t)
-
-			in := dynamicInput{
-				Size:            3,
-				CustomEntry:     customEntry,
-				CustomUrlsetUrl: customUrl,
-			}
-			var out bufferOuput
-
-			Ω(in.HasNextAdvances).Should(BeFalse())
-			Ω(WriteAll(&out, &in)).Should(BeNil())
-			assertOutput(&out, in.Size)
-		})
-
-		t.Run("maxSingleSitemap", func(t *testing.T) {
-			RegisterTestingT(t)
-
-			in := dynamicInput{
-				Size:            50_000,
-				CustomEntry:     customEntry,
-				CustomUrlsetUrl: customUrl,
-			}
-			var out bufferOuput
-
-			Ω(in.HasNextAdvances).Should(BeFalse())
-			Ω(WriteAll(&out, &in)).Should(BeNil())
-			assertOutput(&out, in.Size)
-		})
-
-		t.Run("minTwoSitemaps", func(t *testing.T) {
-			RegisterTestingT(t)
-
-			in := dynamicInput{
-				Size:            50_000 + 1,
-				CustomEntry:     customEntry,
-				CustomUrlsetUrl: customUrl,
-			}
-			var out bufferOuput
-
-			Ω(in.HasNextAdvances).Should(BeFalse())
-			Ω(WriteAll(&out, &in)).Should(BeNil())
-			assertOutput(&out, in.Size)
-		})
-
-		t.Run("maxTwoSitemaps", func(t *testing.T) {
-			RegisterTestingT(t)
-
-			in := dynamicInput{
-				Size:            50_000 * 2,
-				CustomEntry:     customEntry,
-				CustomUrlsetUrl: customUrl,
-			}
-			var out bufferOuput
-
-			Ω(in.HasNextAdvances).Should(BeFalse())
-			Ω(WriteAll(&out, &in)).Should(BeNil())
-			assertOutput(&out, in.Size)
-		})
-
-		t.Run("multipleSitemaps", func(t *testing.T) {
-			RegisterTestingT(t)
-
-			in := dynamicInput{
-				Size:            50_000*3 + 123,
-				CustomEntry:     customEntry,
-				CustomUrlsetUrl: customUrl,
-			}
-			var out bufferOuput
-
-			Ω(in.HasNextAdvances).Should(BeFalse())
-			Ω(WriteAll(&out, &in)).Should(BeNil())
-			assertOutput(&out, in.Size)
-		})
-	})
-
-	t.Run("hasNextAdvances", func(t *testing.T) {
-		t.Run("inputInvariant", func(t *testing.T) {
-			RegisterTestingT(t)
-
-			in := dynamicInput{
-				Size:            3,
-				CustomEntry:     customEntry,
-				CustomUrlsetUrl: customUrl,
-				HasNextAdvances: true,
-			}
-
-			Ω(in.HasNextAdvances).Should(BeTrue())
-			Ω(in.Next()).ShouldNot(BeNil())
-			Ω(in.nextIdx).Should(Equal(0))
-			Ω(in.Next()).ShouldNot(BeNil())
-			Ω(in.nextIdx).Should(Equal(0))
-
-			Ω(in.HasNext()).Should(BeTrue())
-			Ω(in.nextIdx).Should(Equal(1))
-			Ω(in.Next()).ShouldNot(BeNil())
-			Ω(in.nextIdx).Should(Equal(1))
-			Ω(in.Next()).ShouldNot(BeNil())
-			Ω(in.nextIdx).Should(Equal(1))
-		})
-
-		t.Run("shortSingleSitemap", func(t *testing.T) {
-			RegisterTestingT(t)
-
-			in := dynamicInput{
-				Size:            3,
-				CustomEntry:     customEntry,
-				CustomUrlsetUrl: customUrl,
-				HasNextAdvances: true,
-			}
-			var out bufferOuput
-
-			Ω(in.HasNextAdvances).Should(BeTrue())
-			Ω(WriteAll(&out, &in)).Should(BeNil())
-			assertOutput(&out, in.Size)
-		})
-
-		t.Run("maxSingleSitemap", func(t *testing.T) {
-			RegisterTestingT(t)
-
-			in := dynamicInput{
-				Size:            50_000,
-				CustomEntry:     customEntry,
-				CustomUrlsetUrl: customUrl,
-				HasNextAdvances: true,
-			}
-			var out bufferOuput
-
-			Ω(in.HasNextAdvances).Should(BeTrue())
-			Ω(WriteAll(&out, &in)).Should(BeNil())
-			assertOutput(&out, in.Size)
-		})
-
-		t.Run("minTwoSitemaps", func(t *testing.T) {
-			RegisterTestingT(t)
-
-			in := dynamicInput{
-				Size:            50_000 + 1,
-				CustomEntry:     customEntry,
-				CustomUrlsetUrl: customUrl,
-				HasNextAdvances: true,
-			}
-			var out bufferOuput
-
-			Ω(in.HasNextAdvances).Should(BeTrue())
-			Ω(WriteAll(&out, &in)).Should(BeNil())
-			assertOutput(&out, in.Size)
-		})
-
-		t.Run("maxTwoSitemaps", func(t *testing.T) {
-			RegisterTestingT(t)
-
-			in := dynamicInput{
-				Size:            50_000 * 2,
-				CustomEntry:     customEntry,
-				CustomUrlsetUrl: customUrl,
-				HasNextAdvances: true,
-			}
-			var out bufferOuput
-
-			Ω(in.HasNextAdvances).Should(BeTrue())
-			Ω(WriteAll(&out, &in)).Should(BeNil())
-			assertOutput(&out, in.Size)
-		})
-
-		t.Run("multipleSitemaps", func(t *testing.T) {
-			RegisterTestingT(t)
-
-			in := dynamicInput{
-				Size:            50_000*3 + 123,
-				CustomEntry:     customEntry,
-				CustomUrlsetUrl: customUrl,
-				HasNextAdvances: true,
-			}
-			var out bufferOuput
-
-			Ω(in.HasNextAdvances).Should(BeTrue())
-			Ω(WriteAll(&out, &in)).Should(BeNil())
-			assertOutput(&out, in.Size)
-		})
+		Ω(WriteAll(&out, &in)).Should(BeNil())
+		assertOutput(&out, in.Size)
 	})
 
 	t.Run("failures", func(t *testing.T) {
@@ -441,7 +251,10 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 
 		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(s.writeUrlsetFile(&out, &arrayInput{}, false)).Should(BeNil())
+		var in arrayInput
+		co, err := s.writeUrlsetFile(&out, &in, nil)
+		Ω(err).Should(BeNil())
+		Ω(co).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -449,7 +262,10 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 		`)))
 
 		out.Reset()
-		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: []UrlEntry{{}, {}, {}, {}}}, false)).Should(BeNil())
+		in = arrayInput{Arr: []UrlEntry{{}, {}, {}, {}}}
+		co, err = s.writeUrlsetFile(&out, &in, nil)
+		Ω(err).Should(BeNil())
+		Ω(co).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -489,7 +305,10 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 
 		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries}, false)).Should(BeNil())
+		in := arrayInput{Arr: entries}
+		co, err := s.writeUrlsetFile(&out, &in, nil)
+		Ω(err).Should(BeNil())
+		Ω(co).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -520,7 +339,10 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 
 		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries}, false)).Should(BeNil())
+		in := arrayInput{Arr: entries}
+		co, err := s.writeUrlsetFile(&out, &in, nil)
+		Ω(err).Should(BeNil())
+		Ω(co).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -548,7 +370,10 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 		}
 
 		out.Reset()
-		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries}, false)).Should(BeNil())
+		in = arrayInput{Arr: entries}
+		co, err = s.writeUrlsetFile(&out, &in, nil)
+		Ω(err).Should(BeNil())
+		Ω(co).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -598,7 +423,10 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 
 		var s sitemapWriter
 		var out bytes.Buffer
-		Ω(s.writeUrlsetFile(&out, &arrayInput{Arr: entries}, false)).Should(BeNil())
+		in := arrayInput{Arr: entries}
+		co, err := s.writeUrlsetFile(&out, &in, nil)
+		Ω(err).Should(BeNil())
+		Ω(co).Should(BeNil())
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -632,8 +460,13 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 			}
 
 			var s sitemapWriter
-			Ω(s.writeUrlsetFile(ioutil.Discard, &in, false)).
-				Should(MatchError("max 50K capacity is reached"))
+			co, err := s.writeUrlsetFile(ioutil.Discard, &in, nil)
+			Ω(err).Should(MatchError("max 50K capacity is reached"))
+			Ω(co).Should(Equal(&UrlEntry{
+				Loc:     "http://www.example.com/qweqwe",
+				LastMod: minDate.AddDate(1, 2, 3),
+				Images:  []string{"http://www.example.com/qweqwe/thumb.jpg"},
+			}))
 		})
 
 		t.Run("failingWriter", func(t *testing.T) {
@@ -649,10 +482,54 @@ func TestSitemapWriter_WriteUrlsetFile(t *testing.T) {
 			}
 
 			var s sitemapWriter
-			Ω(s.writeUrlsetFile(&failingWriter{}, &in, false)).
-				Should(MatchError("failingWriter error"))
+			co, err := s.writeUrlsetFile(&failingWriter{}, &in, nil)
+			Ω(err).Should(MatchError("failingWriter error"))
+			Ω(co).Should(BeNil())
 		})
 	})
+
+	t.Run("carryOver", func(t *testing.T) {
+		RegisterTestingT(t)
+
+		carryOver := UrlEntry{
+			Loc:     "co",
+			LastMod: time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+		entries := []UrlEntry{
+			{
+				Loc:     "one",
+				LastMod: time.Date(1999, 12, 31, 23, 59, 59, 0, time.UTC),
+			},
+			{
+				Loc:     "two",
+				LastMod: time.Date(2015, 7, 22, 15, 48, 2, 0, time.UTC),
+			},
+		}
+
+		var s sitemapWriter
+		var out bytes.Buffer
+		in := arrayInput{Arr: entries}
+		co, err := s.writeUrlsetFile(&out, &in, &carryOver)
+		Ω(err).Should(BeNil())
+		Ω(co).Should(BeNil())
+		Ω(out.String()).Should(Equal(strings.TrimSpace(`
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <url>
+    <loc>co</loc>
+    <lastmod>2001-01-01T00:00:00Z</lastmod>
+  </url>
+  <url>
+    <loc>one</loc>
+  </url>
+  <url>
+    <loc>two</loc>
+    <lastmod>2015-07-22T15:48:02Z</lastmod>
+  </url>
+</urlset>
+		`)))
+	})
+
 }
 
 func TestSitemapWriter_WriteIndexFile(t *testing.T) {
@@ -811,7 +688,7 @@ func assertOutput(out *bufferOuput, expSize int) {
 
 		totalLocs += len(s.Locs)
 		for j := 0; j < nlocs; j++ {
-			Ω(s.Locs[j]).Should(Equal(fmt.Sprintf("http://goiguide.com/%d", urlsetOffset+j+1)))
+			Ω(s.Locs[j]).Should(Equal(fmt.Sprintf("http://goiguide.com/%d", urlsetOffset+j)))
 		}
 	}
 	Ω(totalLocs).Should(Equal(expSize))
@@ -824,14 +701,13 @@ type arrayInput struct {
 	nextIdx int
 }
 
-func (a arrayInput) HasNext() bool {
-	return a.nextIdx < len(a.Arr)
-}
-
 func (a *arrayInput) Next() *UrlEntry {
-	idx := a.nextIdx
+	if a.nextIdx >= len(a.Arr) {
+		return nil
+	}
+
 	a.nextIdx++
-	return &a.Arr[idx]
+	return &a.Arr[a.nextIdx-1]
 }
 
 func (a *arrayInput) GetUrlsetUrl(idx int) string {
@@ -888,7 +764,6 @@ type dynamicInput struct {
 	DefaultEntry    UrlEntry
 	CustomEntry     func(int) *UrlEntry
 	CustomUrlsetUrl func(int) string
-	HasNextAdvances bool
 
 	nextIdx int
 }
@@ -897,21 +772,14 @@ func (d *dynamicInput) Reset() {
 	d.nextIdx = 0
 }
 
-func (d *dynamicInput) HasNext() bool {
-	idx := d.nextIdx
-	if d.HasNextAdvances {
-		d.nextIdx++
-	}
-	return idx < d.Size
-}
-
 func (d *dynamicInput) Next() *UrlEntry {
-	if !d.HasNextAdvances {
-		d.nextIdx++
+	if d.nextIdx >= d.Size {
+		return nil
 	}
-	idx := d.nextIdx
+
+	d.nextIdx++
 	if d.CustomEntry != nil {
-		return d.CustomEntry(idx)
+		return d.CustomEntry(d.nextIdx - 1)
 	}
 
 	return &d.DefaultEntry
@@ -979,7 +847,7 @@ func BenchmarkWriteUrlset(b *testing.B) {
 			in.Size = size
 			for n := 0; n < b.N; n++ {
 				in.Reset()
-				_ = s.writeUrlsetFile(ioutil.Discard, &in, false)
+				_, _ = s.writeUrlsetFile(ioutil.Discard, &in, nil)
 			}
 		})
 	}


### PR DESCRIPTION
This PR removes `Input.HasNext()` method. Instead, it introduces a new invariant: `Input.Next()` must return `nil` when the iteration is done. It is built on top of https://github.com/PlanitarInc/go-sitemap/pull/17. It solves the same problem that https://github.com/PlanitarInc/go-sitemap/pull/17 aims to solve but it simplifies the solution a bit by reducing the input interface.

Additionally, it removes `errMaxCapReached` error type used internally. Now that we explicitly return a carry-over entry, it is not needed.

### Benchmarks

No changes compared to https://github.com/PlanitarInc/go-sitemap/pull/17: same allocations, maybe a bit faster because `HasNext()` is gone.

```
$ go test -run '^$' -bench . -benchmem | tee new2.bench
goos: darwin
goarch: amd64
pkg: github.com/PlanitarInc/go-sitemap
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkWriteAll/1-12                      	 1328336	       945.2 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/10-12                     	  150031	      6808 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/100-12                    	   17624	     62340 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/1000-12                   	    1898	    627547 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/10000-12                  	     192	   6315018 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/100000-12                 	      18	  62742897 ns/op	     160 B/op	       4 allocs/op
BenchmarkWriteAll/1000000-12                	       2	 632302752 ns/op	     736 B/op	      22 allocs/op
BenchmarkWriteUrlset/1-12                   	 1720742	       693.7 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/10-12                  	  185407	      6428 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/100-12                 	   19058	     62912 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/1000-12                	    1857	    648849 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/10000-12               	     189	   6213696 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/100000-12              	      37	  31669197 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/1000000-12             	      34	  31461020 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/1-12                    	 9459012	       126.5 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/10-12                   	 1356752	       877.8 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/100-12                  	  137701	      8257 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/1000-12                 	   14607	     84025 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/10000-12                	    1435	    816697 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/100000-12               	     146	   8216622 ns/op	      32 B/op	       1 allocs/op
BenchmarkSitemapWriter_writeXmlString/short-12         	32062255	        38.36 ns/op	       0 B/op	       0 allocs/op
BenchmarkSitemapWriter_writeXmlString/long-12          	 5126026	       211.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkSitemapWriter_writeXmlTime/utc-12             	 5928306	       203.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkSitemapWriter_writeXmlTime/custom-12          	 5191456	       217.9 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/PlanitarInc/go-sitemap	37.201s
```

Comparison to master:

```
$ benchcmp old.bench new2.bench
benchcmp is deprecated in favor of benchstat: https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
benchmark                                          old ns/op     new ns/op     delta
BenchmarkWriteAll/1-12                             966           945           -2.15%
BenchmarkWriteAll/10-12                            7404          6808          -8.05%
BenchmarkWriteAll/100-12                           84750         62340         -26.44%
BenchmarkWriteAll/1000-12                          822508        627547        -23.70%
BenchmarkWriteAll/10000-12                         7210228       6315018       -12.42%
BenchmarkWriteAll/100000-12                        73317026      62742897      -14.42%
BenchmarkWriteAll/1000000-12                       695820800     632302752     -9.13%
BenchmarkWriteUrlset/1-12                          909           694           -23.65%
BenchmarkWriteUrlset/10-12                         8215          6428          -21.75%
BenchmarkWriteUrlset/100-12                        76855         62912         -18.14%
BenchmarkWriteUrlset/1000-12                       745129        648849        -12.92%
BenchmarkWriteUrlset/10000-12                      7530459       6213696       -17.49%
BenchmarkWriteUrlset/100000-12                     40530718      31669197      -21.86%
BenchmarkWriteUrlset/1000000-12                    38309880      31461020      -17.88%
BenchmarkWriteIndex/1-12                           167           126           -24.34%
BenchmarkWriteIndex/10-12                          1155          878           -24.00%
BenchmarkWriteIndex/100-12                         10980         8257          -24.80%
BenchmarkWriteIndex/1000-12                        97846         84025         -14.13%
BenchmarkWriteIndex/10000-12                       985195        816697        -17.10%
BenchmarkWriteIndex/100000-12                      10004047      8216622       -17.87%
BenchmarkSitemapWriter_writeXmlString/short-12     45.6          38.4          -15.84%
BenchmarkSitemapWriter_writeXmlString/long-12      259           212           -18.14%
BenchmarkSitemapWriter_writeXmlTime/utc-12         249           204           -18.37%
BenchmarkSitemapWriter_writeXmlTime/custom-12      277           218           -21.39%

benchmark                                          old allocs     new allocs     delta
BenchmarkWriteAll/1-12                             3              3              +0.00%
BenchmarkWriteAll/10-12                            3              3              +0.00%
BenchmarkWriteAll/100-12                           3              3              +0.00%
BenchmarkWriteAll/1000-12                          3              3              +0.00%
BenchmarkWriteAll/10000-12                         3              3              +0.00%
BenchmarkWriteAll/100000-12                        4              4              +0.00%
BenchmarkWriteAll/1000000-12                       22             22             +0.00%
BenchmarkWriteUrlset/1-12                          1              1              +0.00%
BenchmarkWriteUrlset/10-12                         1              1              +0.00%
BenchmarkWriteUrlset/100-12                        1              1              +0.00%
BenchmarkWriteUrlset/1000-12                       1              1              +0.00%
BenchmarkWriteUrlset/10000-12                      1              1              +0.00%
BenchmarkWriteUrlset/100000-12                     1              1              +0.00%
BenchmarkWriteUrlset/1000000-12                    1              1              +0.00%
BenchmarkWriteIndex/1-12                           1              1              +0.00%
BenchmarkWriteIndex/10-12                          1              1              +0.00%
BenchmarkWriteIndex/100-12                         1              1              +0.00%
BenchmarkWriteIndex/1000-12                        1              1              +0.00%
BenchmarkWriteIndex/10000-12                       1              1              +0.00%
BenchmarkWriteIndex/100000-12                      1              1              +0.00%
BenchmarkSitemapWriter_writeXmlString/short-12     0              0              +0.00%
BenchmarkSitemapWriter_writeXmlString/long-12      0              0              +0.00%
BenchmarkSitemapWriter_writeXmlTime/utc-12         0              0              +0.00%
BenchmarkSitemapWriter_writeXmlTime/custom-12      0              0              +0.00%

benchmark                                          old bytes     new bytes     delta
BenchmarkWriteAll/1-12                             128           128           +0.00%
BenchmarkWriteAll/10-12                            128           128           +0.00%
BenchmarkWriteAll/100-12                           128           128           +0.00%
BenchmarkWriteAll/1000-12                          128           128           +0.00%
BenchmarkWriteAll/10000-12                         128           128           +0.00%
BenchmarkWriteAll/100000-12                        160           160           +0.00%
BenchmarkWriteAll/1000000-12                       736           736           +0.00%
BenchmarkWriteUrlset/1-12                          32            32            +0.00%
BenchmarkWriteUrlset/10-12                         32            32            +0.00%
BenchmarkWriteUrlset/100-12                        32            32            +0.00%
BenchmarkWriteUrlset/1000-12                       32            32            +0.00%
BenchmarkWriteUrlset/10000-12                      32            32            +0.00%
BenchmarkWriteUrlset/100000-12                     32            32            +0.00%
BenchmarkWriteUrlset/1000000-12                    32            32            +0.00%
BenchmarkWriteIndex/1-12                           32            32            +0.00%
BenchmarkWriteIndex/10-12                          32            32            +0.00%
BenchmarkWriteIndex/100-12                         32            32            +0.00%
BenchmarkWriteIndex/1000-12                        32            32            +0.00%
BenchmarkWriteIndex/10000-12                       32            32            +0.00%
BenchmarkWriteIndex/100000-12                      32            32            +0.00%
BenchmarkSitemapWriter_writeXmlString/short-12     0             0             +0.00%
BenchmarkSitemapWriter_writeXmlString/long-12      0             0             +0.00%
BenchmarkSitemapWriter_writeXmlTime/utc-12         0             0             +0.00%
BenchmarkSitemapWriter_writeXmlTime/custom-12      0             0             +0.00%
```