### PR TITLE
Fix contents of index file

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ The output:
 
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
+  <sitemap>
     <loc>https://goiguide.com/sitemap-0.xml</loc>
-  </url>
+  </sitemap>
 </sitemapindex>
 ```
 

--- a/channel-input_test.go
+++ b/channel-input_test.go
@@ -159,9 +159,9 @@ func TestWriteAll_ChannelInput(t *testing.T) {
 		Ω(out.index.String()).Should(MatchXML(`
 			<?xml version="1.0" encoding="UTF-8"?>
 			<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-			  <url>
+			  <sitemap>
 				<loc>channel input urlset 0</loc>
-			  </url>
+			  </sitemap>
 			</sitemapindex>
 		`))
 
@@ -206,9 +206,9 @@ func TestWriteAll_ChannelInput(t *testing.T) {
 		Ω(out.index.String()).Should(MatchXML(`
 			<?xml version="1.0" encoding="UTF-8"?>
 			<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-			  <url>
+			  <sitemap>
 				<loc>channel input urlset 0</loc>
-			  </url>
+			  </sitemap>
 			</sitemapindex>
 		`))
 

--- a/example_test.go
+++ b/example_test.go
@@ -57,9 +57,9 @@ func ExampleWriteAll_stdout() {
 	//
 	// <?xml version="1.0" encoding="UTF-8"?>
 	// <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-	//   <url>
+	//   <sitemap>
 	//     <loc>https://goiguide.com/sitemap-0.xml</loc>
-	//   </url>
+	//   </sitemap>
 	// </sitemapindex>
 }
 
@@ -119,9 +119,9 @@ func ExampleWriteAll_buffers() {
 	//
 	// <?xml version="1.0" encoding="UTF-8"?>
 	// <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-	//   <url>
+	//   <sitemap>
 	//     <loc>https://goiguide.com/sitemap-0.xml</loc>
-	//   </url>
+	//   </sitemap>
 	// </sitemapindex>
 }
 
@@ -162,9 +162,9 @@ func ExampleWriteAll_dynamicInput() {
 
 	// <?xml version="1.0" encoding="UTF-8"?>
 	// <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-	//   <url>
+	//   <sitemap>
 	//     <loc>https://goiguide.com/sitemap-00.xml</loc>
-	//   </url>
+	//   </sitemap>
 	// </sitemapindex>
 }
 

--- a/sitemap.go
+++ b/sitemap.go
@@ -41,7 +41,7 @@ func (s *sitemapWriter) writeIndexFile(w io.Writer, in Input, nfiles int) error 
 
 	_, _ = abortWriter.Write(indexHeader)
 	for i := 0; i < nfiles; i++ {
-		s.writeXmlUrlLoc(&abortWriter, in.GetUrlsetUrl(i))
+		s.writeXmlSitemapLoc(&abortWriter, in.GetUrlsetUrl(i))
 	}
 	_, _ = abortWriter.Write(indexFooter)
 
@@ -110,12 +110,12 @@ func (s *sitemapWriter) writeXmlUrlEntry(w io.Writer, e *UrlEntry) {
 	_, _ = w.Write(tagUrlClose)
 }
 
-func (s *sitemapWriter) writeXmlUrlLoc(w io.Writer, loc string) {
-	_, _ = w.Write(tagUrlOpen)
+func (s *sitemapWriter) writeXmlSitemapLoc(w io.Writer, loc string) {
+	_, _ = w.Write(tagSitemapOpen)
 	_, _ = w.Write(tagLocOpen)
 	s.writeXmlString(w, loc)
 	_, _ = w.Write(tagLocClose)
-	_, _ = w.Write(tagUrlClose)
+	_, _ = w.Write(tagSitemapClose)
 }
 
 func (s *sitemapWriter) writeXmlString(w io.Writer, str string) {
@@ -150,6 +150,8 @@ var (
 	)
 	urlsetFooter = []byte(`</urlset>`)
 
+	tagSitemapOpen  = []byte("  <sitemap>\n")
+	tagSitemapClose = []byte("  </sitemap>\n")
 	tagUrlOpen      = []byte("  <url>\n")
 	tagUrlClose     = []byte("  </url>\n")
 	tagLocOpen      = []byte("    <loc>")

--- a/sitemap_test.go
+++ b/sitemap_test.go
@@ -43,9 +43,9 @@ func TestWriteAll(t *testing.T) {
 		Ω(out.index.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
+  <sitemap>
     <loc>urlset 000</loc>
-  </url>
+  </sitemap>
 </sitemapindex>
 		`)))
 
@@ -71,9 +71,9 @@ func TestWriteAll(t *testing.T) {
 		Ω(out.index.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
+  <sitemap>
     <loc>urlset 000</loc>
-  </url>
+  </sitemap>
 </sitemapindex>
 		`)))
 
@@ -122,9 +122,9 @@ func TestWriteAll(t *testing.T) {
 		Ω(out.index.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
+  <sitemap>
     <loc>urlset 000</loc>
-  </url>
+  </sitemap>
 </sitemapindex>
 		`)))
 
@@ -145,12 +145,12 @@ func TestWriteAll(t *testing.T) {
 		Ω(out.index.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
+  <sitemap>
     <loc>urlset 000</loc>
-  </url>
-  <url>
+  </sitemap>
+  <sitemap>
     <loc>urlset 001</loc>
-  </url>
+  </sitemap>
 </sitemapindex>
 		`)))
 
@@ -559,15 +559,15 @@ func TestSitemapWriter_WriteIndexFile(t *testing.T) {
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
+  <sitemap>
     <loc>urlset no. 1</loc>
-  </url>
-  <url>
+  </sitemap>
+  <sitemap>
     <loc>urlset no. 2</loc>
-  </url>
-  <url>
+  </sitemap>
+  <sitemap>
     <loc>urlset no. 3</loc>
-  </url>
+  </sitemap>
 </sitemapindex>
 		`)))
 	})
@@ -585,18 +585,18 @@ func TestSitemapWriter_WriteIndexFile(t *testing.T) {
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
+  <sitemap>
     <loc>custom @000@</loc>
-  </url>
-  <url>
+  </sitemap>
+  <sitemap>
     <loc>custom @001@</loc>
-  </url>
-  <url>
+  </sitemap>
+  <sitemap>
     <loc>custom @002@</loc>
-  </url>
-  <url>
+  </sitemap>
+  <sitemap>
     <loc>custom @003@</loc>
-  </url>
+  </sitemap>
 </sitemapindex>
 		`)))
 	})
@@ -623,21 +623,21 @@ func TestSitemapWriter_WriteIndexFile(t *testing.T) {
 		Ω(out.String()).Should(Equal(strings.TrimSpace(`
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
+  <sitemap>
     <loc>http://www.example.com/q=&#34;&lt;&#39;a&#39;&amp;&#39;b&#39;&gt;</loc>
-  </url>
-  <url>
+  </sitemap>
+  <sitemap>
     <loc>🥴.com/</loc>
-  </url>
-  <url>
+  </sitemap>
+  <sitemap>
     <loc>гоуайгайд.ком/</loc>
-  </url>
-  <url>
+  </sitemap>
+  <sitemap>
     <loc>🤟.🤙/?idx=&lt;03&gt;&amp;e=/&#39;🤪?</loc>
-  </url>
-  <url>
+  </sitemap>
+  <sitemap>
     <loc>🤟.🤙/?idx=&lt;04&gt;&amp;e=/&#39;🤪?</loc>
-  </url>
+  </sitemap>
 </sitemapindex>
 		`)))
 	})
@@ -660,13 +660,17 @@ func TestSitemapWriter_WriteIndexFile(t *testing.T) {
 }
 
 func assertOutput(out *bufferOuput, expSize int) {
-	type simpleSitemap struct {
+	type sitemapList struct {
+		Locs []string `xml:"sitemap>loc"`
+	}
+
+	type urlList struct {
 		Locs []string `xml:"url>loc"`
 	}
 
 	nsitemaps := int(math.Ceil(float64(expSize) / 50_000))
 
-	var index simpleSitemap
+	var index sitemapList
 	Ω(xml.Unmarshal(out.index.Bytes(), &index)).Should(BeNil())
 	Ω(index.Locs).Should(HaveLen(nsitemaps))
 	for i := 0; i < nsitemaps; i++ {
@@ -676,7 +680,7 @@ func assertOutput(out *bufferOuput, expSize int) {
 	Ω(out.sitemaps).Should(HaveLen(nsitemaps))
 	var totalLocs int
 	for i := 0; i < nsitemaps; i++ {
-		var s simpleSitemap
+		var s urlList
 		Ω(xml.Unmarshal(out.sitemaps[i].Bytes(), &s)).Should(BeNil())
 
 		urlsetOffset := i * 50_000


### PR DESCRIPTION
This PR is a fixup for https://github.com/PlanitarInc/go-sitemap/pull/12.

The index file structure should be as follows (according to https://www.sitemaps.org/protocol.html):
1. sitemapindex
   2. sitemap
      3. loc

Instead, the current implementation generates a file as follows:
1. sitemapindex
   2. url
      3. loc

That is, the element on the second level should be `sitemap` rather than
`url`. This commit fixes it.

### Benchmarks

No much changes in the benchmarks:

```
$ go test -run '^$' -bench . -benchmem
goos: darwin
goarch: amd64
pkg: github.com/PlanitarInc/go-sitemap
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkWriteAll/1-12                      	 1335984	       892.9 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/10-12                     	  177658	      6630 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/100-12                    	   18532	     63532 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/1000-12                   	    1874	    635058 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/10000-12                  	     189	   6401617 ns/op	     128 B/op	       3 allocs/op
BenchmarkWriteAll/100000-12                 	      18	  63876363 ns/op	     160 B/op	       4 allocs/op
BenchmarkWriteAll/1000000-12                	       2	 720920523 ns/op	     736 B/op	      22 allocs/op
BenchmarkWriteUrlset/1-12                   	 1631001	       739.5 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/10-12                  	  156862	      7778 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/100-12                 	   18118	     70144 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/1000-12                	    1568	    725226 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/10000-12               	     177	   6684363 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/100000-12              	      33	  33167592 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteUrlset/1000000-12             	      36	  32913997 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/1-12                    	 9136713	       136.4 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/10-12                   	 1292866	       898.4 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/100-12                  	  141624	      8588 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/1000-12                 	   14092	     86043 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/10000-12                	    1248	    899017 ns/op	      32 B/op	       1 allocs/op
BenchmarkWriteIndex/100000-12               	     130	   9056684 ns/op	      32 B/op	       1 allocs/op
BenchmarkSitemapWriter_writeXmlString/short-12         	31610180	        42.93 ns/op	       0 B/op	       0 allocs/op
BenchmarkSitemapWriter_writeXmlString/long-12          	 4844755	       220.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkSitemapWriter_writeXmlTime/utc-12             	 5827927	       213.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkSitemapWriter_writeXmlTime/custom-12          	 5044532	       250.9 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/PlanitarInc/go-sitemap	39.184s
```